### PR TITLE
feat: Add Object-Oriented Programming section to Python page

### DIFF
--- a/components/pageComponents/Python/AbstractionConcept.tsx
+++ b/components/pageComponents/Python/AbstractionConcept.tsx
@@ -1,17 +1,39 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import CodeSnippet from '../../common/CodeSnippet';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+const PAYMENT_METHODS = [
+  { name: 'CreditCard', verb: 'by credit card' },
+  { name: 'PayPal', verb: 'via PayPal' },
+  { name: 'BankTransfer', verb: 'via bank transfer' },
+];
 
 export default function AbstractionConcept() {
+  const [method, setMethod] = useState('CreditCard');
+  const [amount, setAmount] = useState('50');
+  const [log, setLog] = useState<string[]>([]);
+
+  const checkout = () => {
+    const m = PAYMENT_METHODS.find((p) => p.name === method)!;
+    const a = parseInt(amount, 10) || 0;
+    setLog((prev) => [...prev, `checkout(${m.name}(), ${a})  ->  "Paid $${a} ${m.verb}"`].slice(-6));
+  };
+
+  const clearLog = () => setLog([]);
+
   const abstractionCode = [
     'from abc import ABC, abstractmethod',
     '',
@@ -169,6 +191,56 @@ class PaymentMethod(ABC):
           <Alert severity="info" sx={{ mt: 2 }}>
             <Typography variant="body2">
               <code>checkout</code> never needs to change when you add a new payment type. As long as the new class honors the <code>PaymentMethod</code> contract, it just works.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Try It Yourself: One Contract, Many Implementations">
+          <Typography variant="body2" paragraph>
+            Every payment type below fulfills the same <code>PaymentMethod</code> contract by implementing <code>pay()</code>. The <code>checkout()</code> function calls <code>pay()</code> without knowing or caring which specific type it received. Pick a method, enter an amount, and run it.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="chip-row" style={{ marginBottom: 14 }}>
+              {PAYMENT_METHODS.map((p) => (
+                <button
+                  key={p.name}
+                  className={`select-chip ${method === p.name ? 'selected' : ''}`}
+                  onClick={() => setMethod(p.name)}
+                >
+                  {p.name}
+                </button>
+              ))}
+            </div>
+
+            <div className="ds-controls">
+              <TextField
+                label="amount"
+                type="number"
+                size="small"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') checkout(); }}
+                sx={{ width: 120 }}
+              />
+              <Button variant="contained" onClick={checkout}>Run checkout()</Button>
+              <Button variant="text" color="secondary" onClick={clearLog} disabled={log.length === 0}>Clear</Button>
+            </div>
+
+            <div className="output-panel">
+              {log.length === 0 ? (
+                <span className="muted"># checkout() treats every payment method the same way</span>
+              ) : (
+                log.map((line, i) => (
+                  <div key={i}><span className="out-prompt">&gt;&gt;&gt; </span>{line}</div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Each method produces a different result, yet the calling code is identical. The abstract contract is what lets <code>checkout()</code> remain simple while supporting any number of payment types.
             </Typography>
           </Alert>
         </Section>

--- a/components/pageComponents/Python/AbstractionConcept.tsx
+++ b/components/pageComponents/Python/AbstractionConcept.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import CodeSnippet from '../../common/CodeSnippet';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function AbstractionConcept() {
+  const abstractionCode = [
+    'from abc import ABC, abstractmethod',
+    '',
+    'class PaymentMethod(ABC):',
+    '    @abstractmethod',
+    '    def pay(self, amount):',
+    '        pass',
+    '',
+    'class CreditCard(PaymentMethod):',
+    '    def pay(self, amount):',
+    '        return f"Paid ${amount} by credit card"',
+    '',
+    '# PaymentMethod() would raise an error — it is abstract',
+    'card = CreditCard()',
+    'print(card.pay(50))   # Paid $50 by credit card'
+  ];
+
+  const abstractionSteps = [
+    {
+      label: 'Import the Tools',
+      desc: 'ABC and abstractmethod come from the abc module',
+      highlight: 'from abc import ABC, abstractmethod'
+    },
+    {
+      label: 'Define an Abstract Base',
+      desc: 'PaymentMethod(ABC) declares a contract, not a usable class',
+      highlight: 'class PaymentMethod(ABC):'
+    },
+    {
+      label: 'Require a Method',
+      desc: '@abstractmethod forces every child to provide pay',
+      highlight: ['    @abstractmethod', '    def pay(self, amount):']
+    },
+    {
+      label: 'Fulfill the Contract',
+      desc: 'CreditCard implements the required pay method',
+      highlight: ['class CreditCard(PaymentMethod):', '        return f"Paid ${amount} by credit card"']
+    },
+    {
+      label: 'Can\'t Skip It',
+      desc: 'You cannot create a PaymentMethod directly — only complete children',
+      highlight: '# PaymentMethod() would raise an error — it is abstract'
+    },
+    {
+      label: 'Use the Concrete Class',
+      desc: 'CreditCard is complete, so it works normally',
+      highlight: 'print(card.pay(50))   # Paid $50 by credit card'
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Abstraction"
+      description="Hide complex details behind a simple interface, and define contracts that every implementation must follow."
+    >
+      <TableOfContents numbered>
+        <Section title="What is Abstraction?">
+          <Typography variant="body2" paragraph>
+            <strong>Abstraction</strong> means exposing <em>only the essential features</em> of something while hiding the messy details. You focus on <em>what</em> an object does, not <em>how</em> it does it.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            When you drive a car, you use the steering wheel and pedals. You don&apos;t need to understand combustion or transmissions. The complex machinery is abstracted away behind a simple interface — and the same idea makes large programs manageable.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Abstraction vs. Encapsulation
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>Encapsulation</strong> is about <em>hiding the data</em> and protecting it behind methods.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Abstraction</strong> is about <em>hiding the complexity</em> and exposing a clean, simple interface.
+              </Typography>
+              <Typography variant="body2">
+                They work hand in hand: encapsulation is one of the tools you use to achieve abstraction.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Abstract Base Classes">
+          <Typography variant="body2" paragraph>
+            Python provides <strong>abstract base classes (ABCs)</strong> through the <code>abc</code> module. An abstract class defines a <em>contract</em>: it lists methods that must exist, but it can&apos;t be instantiated on its own. Every concrete child is required to fill in those methods.
+          </Typography>
+
+          <CodePartsExplanation
+            code={`from abc import ABC, abstractmethod
+
+class PaymentMethod(ABC):
+    @abstractmethod
+    def pay(self, amount):
+        pass`}
+            parts={[
+              {
+                label: 'ABC base',
+                part: 'class PaymentMethod(ABC):',
+                color: '#9333ea',
+                desc: 'Inheriting from ABC marks this as an abstract class'
+              },
+              {
+                label: 'Abstract method',
+                part: '@abstractmethod',
+                color: '#dc2626',
+                desc: 'Every child class is forced to implement the method below'
+              },
+              {
+                label: 'No body needed',
+                part: 'pass',
+                color: '#059669',
+                desc: 'The abstract class only declares the method, it doesn\'t define it'
+              }
+            ]}
+          />
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Step through to see the contract enforced:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={abstractionCode}
+              steps={abstractionSteps}
+            />
+          </ConceptInfoCard>
+
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Trying to create an object of an abstract class — or a child that forgot to implement an abstract method — raises a <code>TypeError</code>. That&apos;s the contract doing its job.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Why Contracts Help">
+          <Typography variant="body2" paragraph>
+            Once several classes share the same abstract interface, the rest of your program can rely on that interface and treat them interchangeably — abstraction and polymorphism working together.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class PayPal(PaymentMethod):' },
+              { code: '    def pay(self, amount):' },
+              { code: '        return f"Paid ${amount} via PayPal"' },
+              { code: '' },
+              { code: 'def checkout(method, amount):' },
+              { code: '    # Works with ANY PaymentMethod, present or future' },
+              { code: '    print(method.pay(amount))' },
+              { code: '' },
+              { code: 'checkout(CreditCard(), 50)   # Paid $50 by credit card' },
+              { code: 'checkout(PayPal(), 75)       # Paid $75 via PayPal' }
+            ]}
+          />
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              <code>checkout</code> never needs to change when you add a new payment type. As long as the new class honors the <code>PaymentMethod</code> contract, it just works.
+            </Typography>
+          </Alert>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
+++ b/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Slider from '@mui/material/Slider';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type Complexity = {
+  label: string;
+  color: string;
+  steps: (n: number) => number;
+  note: string;
+};
+
+const COMPLEXITIES: Complexity[] = [
+  { label: 'O(1)', color: '#22c55e', steps: () => 1, note: 'Constant — same work no matter the size' },
+  { label: 'O(log n)', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), note: 'Logarithmic — halves the problem each step' },
+  { label: 'O(n)', color: '#3b82f6', steps: (n) => n, note: 'Linear — work grows with the input' },
+  { label: 'O(n log n)', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), note: 'Good sorting algorithms live here' },
+  { label: 'O(n²)', color: '#ef4444', steps: (n) => n * n, note: 'Quadratic — slows down fast' },
+];
+
+export default function AlgorithmAnalysisConcept() {
+  const [n, setN] = useState(16);
+
+  const results = COMPLEXITIES.map((c) => ({ ...c, value: c.steps(n) }));
+  const max = Math.max(...results.map((r) => r.value));
+
+  return (
+    <ConceptWrapper
+      title="Algorithm Analysis & Design"
+      description="An algorithm is a step-by-step recipe for solving a problem. Analysis is how we measure whether that recipe will stay fast as the data grows."
+    >
+      <TableOfContents numbered>
+        <Section title="What is an Algorithm?">
+          <Typography variant="body2" paragraph>
+            An <strong>algorithm</strong> is just a precise list of steps for getting something done — like a <em>cooking recipe</em> or the <em>directions</em> to a friend&apos;s house. Given the same starting ingredients, it always produces the same result.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              A Good Algorithm Is...
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2"><strong>✅ Correct:</strong> it produces the right answer every time</Typography>
+              <Typography variant="body2"><strong>📋 Clear:</strong> each step is unambiguous</Typography>
+              <Typography variant="body2"><strong>🏁 Finite:</strong> it eventually stops</Typography>
+              <Typography variant="body2"><strong>⚡ Efficient:</strong> it doesn&apos;t waste time or memory</Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Why We Measure with Big-O">
+          <Typography variant="body2" paragraph>
+            We don&apos;t measure algorithms in <em>seconds</em>, because that depends on your computer. Instead we count <strong>how the number of steps grows as the input gets bigger</strong>. That growth rate is written with <strong>Big-O notation</strong>.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            The real question Big-O answers is: <em>&quot;If I give this algorithm 10× more data, does it get a little slower, or a lot slower?&quot;</em>
+          </Typography>
+
+          <Alert severity="info">
+            <Typography variant="body2">
+              Big-O describes the <strong>worst case</strong> and ignores constants. We care about the <em>shape</em> of the growth, not the exact step count.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="See How They Grow">
+          <Typography variant="body2" paragraph>
+            Drag the slider to change the input size <strong>n</strong> and watch how many steps each kind of algorithm needs. Notice how <code>O(1)</code> barely moves while <code>O(n²)</code> explodes.
+          </Typography>
+
+          <div className="ds-viz">
+            <Box sx={{ px: 1, mb: 2 }}>
+              <Typography variant="body2" gutterBottom>
+                Input size <strong>n = {n}</strong>
+              </Typography>
+              <Slider
+                value={n}
+                min={1}
+                max={64}
+                onChange={(_, v) => setN(v as number)}
+                valueLabelDisplay="auto"
+              />
+            </Box>
+
+            {results.map((r) => (
+              <div className="bigo-row" key={r.label}>
+                <span className="bigo-label" style={{ color: r.color }}>{r.label}</span>
+                <span className="bigo-track">
+                  <span
+                    className="bigo-fill"
+                    style={{
+                      width: `${Math.max(2, (r.value / max) * 100)}%`,
+                      background: r.color,
+                    }}
+                  >
+                    {r.value <= 9999 ? r.value : '9999+'}
+                  </span>
+                </span>
+                <span className="bigo-steps">steps</span>
+              </div>
+            ))}
+            <p className="ds-caption">Bars are scaled to the slowest algorithm. The number is the actual step count.</p>
+          </div>
+        </Section>
+
+        <Section title="Common Complexities (with Analogies)">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong style={{ color: '#22c55e' }}>O(1) — Constant:</strong> grabbing the first item in a list. Instant, no matter how long the list is.
+              </Typography>
+              <Typography variant="body2">
+                <strong style={{ color: '#14b8a6' }}>O(log n) — Logarithmic:</strong> finding a word in a dictionary by repeatedly splitting it in half.
+              </Typography>
+              <Typography variant="body2">
+                <strong style={{ color: '#3b82f6' }}>O(n) — Linear:</strong> reading every page of a book once.
+              </Typography>
+              <Typography variant="body2">
+                <strong style={{ color: '#f59e0b' }}>O(n log n) — Linearithmic:</strong> the speed of efficient sorting like merge sort.
+              </Typography>
+              <Typography variant="body2">
+                <strong style={{ color: '#ef4444' }}>O(n²) — Quadratic:</strong> comparing every person in a room with every other person (handshakes).
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Designing Algorithms">
+          <Typography variant="body2" paragraph>
+            <strong>Design</strong> is choosing a strategy to attack a problem. A few classic approaches:
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>💪 Brute force:</strong> try every possibility. Simple, but often slow — the &quot;just check everything&quot; approach.
+              </Typography>
+              <Typography variant="body2">
+                <strong>✂️ Divide &amp; conquer:</strong> break the problem into smaller pieces, solve each, and combine. Powers binary search and merge sort.
+              </Typography>
+              <Typography variant="body2">
+                <strong>🪙 Greedy:</strong> make the best-looking choice at each step. Great for things like making change with the fewest coins.
+              </Typography>
+              <Typography variant="body2">
+                <strong>🧠 Dynamic programming:</strong> remember answers to sub-problems so you never solve the same one twice.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The data structure you choose is part of the design. The right structure (a stack, queue, or tree) can turn a slow <code>O(n²)</code> idea into a fast <code>O(n log n)</code> one.
+            </Typography>
+          </Alert>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
+++ b/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
-import Button from '@mui/material/Button';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import CalloutBox from '../../common/CalloutBox';
@@ -20,11 +19,11 @@ type Complexity = {
 };
 
 const COMPLEXITIES: Complexity[] = [
-  { label: 'O(1)', plain: 'Constant', color: '#22c55e', steps: () => 1, analogy: 'Retrieving the first item in a list — instant, regardless of list length.' },
-  { label: 'O(log n)', plain: 'Logarithmic', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), analogy: 'Finding a word in a dictionary by repeatedly splitting it in half.' },
-  { label: 'O(n)', plain: 'Linear', color: '#3b82f6', steps: (n) => n, analogy: 'Reading every page of a book once.' },
-  { label: 'O(n log n)', plain: 'Linearithmic', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), analogy: 'The growth rate of the efficient sorting algorithms used in production.' },
-  { label: 'O(n²)', plain: 'Quadratic', color: '#ef4444', steps: (n) => n * n, analogy: 'Every person in a room shaking hands with every other person.' },
+  { label: 'O(1)', plain: 'Constant', color: '#22c55e', steps: () => 1, analogy: 'Grabbing the first item — instant.' },
+  { label: 'O(log n)', plain: 'Logarithmic', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), analogy: 'Halving a sorted list (binary search).' },
+  { label: 'O(n)', plain: 'Linear', color: '#3b82f6', steps: (n) => n, analogy: 'Reading every page once.' },
+  { label: 'O(n log n)', plain: 'Linearithmic', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), analogy: 'The good sorting algorithms.' },
+  { label: 'O(n²)', plain: 'Quadratic', color: '#ef4444', steps: (n) => n * n, analogy: 'Everyone shaking hands with everyone.' },
 ];
 
 const SCALE_PRESETS = [
@@ -48,80 +47,50 @@ export default function AlgorithmAnalysisConcept() {
   return (
     <ConceptWrapper
       title="Algorithm Analysis & Design"
-      description="An algorithm is a step-by-step procedure for solving a problem. Analysis asks a single practical question: will this procedure remain fast as the data grows?"
+      description="An algorithm is a recipe of steps. Analysis is how we judge whether it stays fast."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
-        <Section title="What Is an Algorithm?">
-          <Typography variant="body2" paragraph>
-            An <strong>algorithm</strong> is simply a precise sequence of steps for accomplishing a task. A cooking recipe is an algorithm, and so are driving directions. Given the same input, following the same steps always produces the same result.
-          </Typography>
+        <Section title="The Big Idea">
+          <CalloutBox title="Gentle, or explode?" type="key-concepts">
+            <Typography variant="body2">
+              An algorithm is a recipe — a set of steps. The one question that matters: <strong>as the data gets bigger, does the work grow gently, or explode?</strong>
+            </Typography>
+          </CalloutBox>
 
-          <div className="ds-viz">
-            <div className="illus-label">A recipe is an algorithm — a clear, ordered sequence of steps:</div>
+          <div className="ds-viz" style={{ marginTop: 16 }}>
             <div className="flow">
               <span className="flow-step">Boil water</span>
               <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">Add pasta</span>
               <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step">Wait 10 minutes</span>
+              <span className="flow-step">Wait</span>
               <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">Drain</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>Done</span>
             </div>
+            <p className="ds-caption">A recipe is an algorithm: clear, ordered steps that always give the same result.</p>
           </div>
-
-          <CalloutBox title="Definition" type="info">
-            <Typography variant="body2">
-              An <strong>algorithm</strong> takes some input and produces a result through a defined set of steps. <strong>Analysis</strong> is the study of how much time and memory those steps require as the input grows.
-            </Typography>
-          </CalloutBox>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="What Makes an Algorithm Good?">
-          <CalloutBox title="The qualities of a good algorithm" type="key-concepts">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Correct</strong> — it produces the right result every time.</Typography>
-              <Typography variant="body2"><strong>Clear</strong> — each step is unambiguous.</Typography>
-              <Typography variant="body2"><strong>Finite</strong> — it always terminates rather than running forever.</Typography>
-              <Typography variant="body2"><strong>Efficient</strong> — it avoids wasting time and memory.</Typography>
-            </Box>
-          </CalloutBox>
+        <Section title="We Measure Steps, Not Seconds">
+          <Typography variant="body2" paragraph>
+            Seconds depend on your computer. So instead we count <strong>how the number of steps grows</strong> as the input grows. That growth pattern gets a shorthand name: <strong>Big-O</strong>, written like <code>O(n)</code> or <code>O(n²)</code>.
+          </Typography>
+          <Typography variant="body2">
+            Don&apos;t worry about the symbols — each one is just a name for a <em>shape</em> of growth. The visuals below show those shapes.
+          </Typography>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Measuring Speed Without a Stopwatch">
+        <Section title="See the Shapes">
           <Typography variant="body2" paragraph>
-            How do we say one algorithm is faster than another? Not in seconds — that depends on the specific machine, what else it is running, and many other factors. Instead, we measure <strong>how the number of steps grows as the input grows</strong>.
-          </Typography>
-          <Typography variant="body2" paragraph>
-            The question this answers is straightforward:
-          </Typography>
-
-          <CalloutBox title="The central question of analysis" type="info">
-            <Typography variant="body2">
-              If the input becomes ten times larger, does the algorithm become slightly slower, or dramatically slower?
-            </Typography>
-          </CalloutBox>
-
-          <Typography variant="body2" paragraph sx={{ mt: 2 }}>
-            That growth rate is given a shorthand label called <strong>Big-O notation</strong>, written as <code>O(n)</code>, <code>O(n²)</code>, and so on. Each label is simply a name for a <em>shape</em> of growth, which the visualizations below make concrete.
-          </Typography>
-        </Section>
-
-        {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Compare the Growth Shapes">
-          <Typography variant="body2" paragraph>
-            Adjust the input size <strong>n</strong> with the slider and observe how many steps each growth rate requires. Notice that <code>O(1)</code> stays flat while <code>O(n²)</code> climbs steeply.
+            Drag the slider. Watch <code>O(1)</code> stay flat while <code>O(n²)</code> shoots up.
           </Typography>
 
           <div className="ds-viz">
             <Box sx={{ px: 1, mb: 2 }}>
-              <Typography variant="body2" gutterBottom>
-                Input size <strong>n = {n}</strong>
-              </Typography>
+              <Typography variant="body2" gutterBottom>n = {n}</Typography>
               <Slider value={n} min={1} max={64} onChange={(_, v) => setN(v as number)} valueLabelDisplay="auto" />
             </Box>
 
@@ -136,24 +105,20 @@ export default function AlgorithmAnalysisConcept() {
                 <span className="bigo-steps">steps</span>
               </div>
             ))}
-            <p className="ds-caption">Bars are scaled to the largest value. The number is the actual step count at this input size.</p>
+            <p className="ds-caption">Bars scaled to the largest. The number is the actual step count.</p>
           </div>
         </Section>
 
-        {/* 5 ----------------------------------------------------------------- */}
-        <Section title="The Same Comparison at Scale">
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Why It Matters at Scale">
           <Typography variant="body2" paragraph>
-            Growth shapes only reveal their importance with large inputs. Choose an input size to see the exact number of steps each growth rate would require.
+            The shapes barely differ for tiny inputs. Pick a big input size and the &quot;gentle vs explode&quot; gap becomes obvious.
           </Typography>
 
           <div className="ds-viz">
             <div className="chip-row" style={{ marginBottom: 16 }}>
               {SCALE_PRESETS.map((p) => (
-                <button
-                  key={p.value}
-                  className={`select-chip ${scaleN === p.value ? 'selected' : ''}`}
-                  onClick={() => setScaleN(p.value)}
-                >
+                <button key={p.value} className={`select-chip ${scaleN === p.value ? 'selected' : ''}`} onClick={() => setScaleN(p.value)}>
                   n = {p.label}
                 </button>
               ))}
@@ -161,109 +126,38 @@ export default function AlgorithmAnalysisConcept() {
 
             {COMPLEXITIES.map((c) => (
               <Box key={c.label} sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
-                <span
-                  style={{
-                    flexShrink: 0,
-                    background: c.color,
-                    color: '#fff',
-                    fontFamily: 'monospace',
-                    fontWeight: 700,
-                    fontSize: 13,
-                    padding: '4px 10px',
-                    borderRadius: 6,
-                    minWidth: 92,
-                    textAlign: 'center',
-                  }}
-                >
+                <span style={{ flexShrink: 0, background: c.color, color: '#fff', fontFamily: 'monospace', fontWeight: 700, fontSize: 13, padding: '4px 10px', borderRadius: 6, minWidth: 92, textAlign: 'center' }}>
                   {c.label}
                 </span>
-                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                  {fmt(c.steps(scaleN))} steps
-                </Typography>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{fmt(c.steps(scaleN))} steps</Typography>
               </Box>
             ))}
-            <p className="ds-caption">
-              At n = {scaleN.toLocaleString()}, the gap between O(log n) and O(n²) is the difference between instant and unusable.
-            </p>
           </div>
 
-          <CalloutBox title="Why this matters" type="success">
+          <CalloutBox title="Connecting back" type="success">
             <Typography variant="body2">
-              At one million items, an O(log n) algorithm needs about 20 steps while an O(n²) algorithm needs a trillion. This is precisely why algorithm analysis drives real engineering decisions.
+              At a million items, <code>O(log n)</code> needs about 20 steps; <code>O(n²)</code> needs a trillion. <strong>Gentle vs explode</strong> — that is the whole point of analysis.
             </Typography>
           </CalloutBox>
         </Section>
 
-        {/* 6 ----------------------------------------------------------------- */}
-        <Section title="The Common Growth Rates">
-          <Typography variant="body2" paragraph>
-            A small set of growth rates covers most situations. Listed from fastest to slowest, each with an everyday analogy:
-          </Typography>
-
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="The Shapes in Plain English">
           <div className="ds-viz">
             {COMPLEXITIES.map((c) => (
-              <Box key={c.label} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, mb: 1.75 }}>
-                <span
-                  style={{
-                    flexShrink: 0,
-                    background: c.color,
-                    color: '#fff',
-                    fontFamily: 'monospace',
-                    fontWeight: 700,
-                    fontSize: 13,
-                    padding: '4px 10px',
-                    borderRadius: 6,
-                    minWidth: 92,
-                    textAlign: 'center',
-                  }}
-                >
+              <Box key={c.label} sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.25 }}>
+                <span style={{ flexShrink: 0, background: c.color, color: '#fff', fontFamily: 'monospace', fontWeight: 700, fontSize: 13, padding: '4px 10px', borderRadius: 6, minWidth: 92, textAlign: 'center' }}>
                   {c.label}
                 </span>
-                <Typography variant="body2">
-                  <strong>{c.plain}.</strong> {c.analogy}
-                </Typography>
+                <Typography variant="body2"><strong>{c.plain}.</strong> {c.analogy}</Typography>
               </Box>
             ))}
           </div>
 
-          <CalloutBox title="The two you will encounter most" type="key-concepts">
+          <CalloutBox title="And the design part?" type="info">
             <Typography variant="body2">
-              <strong>O(n log n)</strong> is the target growth rate for good sorting. <strong>O(n²)</strong> is a warning sign that an algorithm is likely comparing everything to everything — usually an indication that a faster approach exists.
+              <strong>Design</strong> is choosing a strategy that keeps the shape gentle — often <em>divide &amp; conquer</em> (split the problem in half, like binary search) paired with the right data structure (a stack, queue, or tree).
             </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 7 ----------------------------------------------------------------- */}
-        <Section title="Designing Algorithms">
-          <Typography variant="body2" paragraph>
-            <strong>Design</strong> is the act of choosing a strategy before writing code. Several classic approaches recur across many problems:
-          </Typography>
-
-          <CalloutBox title="Common design strategies" type="guide">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1 }}>
-              <Typography variant="body2"><strong>Brute force:</strong> try every possibility. Simple to implement, but often slow.</Typography>
-              <Typography variant="body2"><strong>Divide and conquer:</strong> break the problem into smaller pieces, solve each, then combine. Powers binary search and merge sort.</Typography>
-              <Typography variant="body2"><strong>Greedy:</strong> take the best-looking option at each step. Effective for problems such as making change with the fewest coins.</Typography>
-              <Typography variant="body2"><strong>Dynamic programming:</strong> store the answers to sub-problems so none is ever solved twice.</Typography>
-            </Box>
-          </CalloutBox>
-
-          <CalloutBox title="Data structures are part of the design" type="info">
-            <Typography variant="body2">
-              Choosing the right structure — a stack, a queue, or a tree — can convert a slow O(n²) approach into a fast O(n log n) one. The structure and the algorithm work together.
-            </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 8 ----------------------------------------------------------------- */}
-        <Section title="Key Takeaways">
-          <CalloutBox title="Summary" type="success">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>An algorithm</strong> is a precise sequence of steps for solving a problem.</Typography>
-              <Typography variant="body2"><strong>Big-O</strong> describes how work grows as the input grows, independent of any specific machine.</Typography>
-              <Typography variant="body2"><strong>Efficient growth rates</strong> (O(1), O(log n), O(n log n)) scale to large data; O(n²) does not.</Typography>
-              <Typography variant="body2"><strong>Good design</strong> pairs the right strategy with the right data structure.</Typography>
-            </Box>
           </CalloutBox>
         </Section>
       </TableOfContents>

--- a/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
+++ b/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
@@ -4,26 +4,26 @@ import { useState } from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
 type Complexity = {
   label: string;
+  plain: string;
   color: string;
   steps: (n: number) => number;
-  note: string;
+  analogy: string;
 };
 
 const COMPLEXITIES: Complexity[] = [
-  { label: 'O(1)', color: '#22c55e', steps: () => 1, note: 'Constant — same work no matter the size' },
-  { label: 'O(log n)', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), note: 'Logarithmic — halves the problem each step' },
-  { label: 'O(n)', color: '#3b82f6', steps: (n) => n, note: 'Linear — work grows with the input' },
-  { label: 'O(n log n)', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), note: 'Good sorting algorithms live here' },
-  { label: 'O(n²)', color: '#ef4444', steps: (n) => n * n, note: 'Quadratic — slows down fast' },
+  { label: 'O(1)', plain: 'Constant', color: '#22c55e', steps: () => 1, analogy: 'Grabbing the first item in a list — instant, no matter how long the list is.' },
+  { label: 'O(log n)', plain: 'Logarithmic', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), analogy: 'Finding a word in a dictionary by repeatedly splitting it in half.' },
+  { label: 'O(n)', plain: 'Linear', color: '#3b82f6', steps: (n) => n, analogy: 'Reading every page of a book once.' },
+  { label: 'O(n log n)', plain: 'Linearithmic', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), analogy: 'The speed of the good sorting algorithms real programs use.' },
+  { label: 'O(n²)', plain: 'Quadratic', color: '#ef4444', steps: (n) => n * n, analogy: 'Everyone in a room shaking hands with everyone else.' },
 ];
 
 export default function AlgorithmAnalysisConcept() {
@@ -35,45 +35,73 @@ export default function AlgorithmAnalysisConcept() {
   return (
     <ConceptWrapper
       title="Algorithm Analysis & Design"
-      description="An algorithm is a step-by-step recipe for solving a problem. Analysis is how we measure whether that recipe will stay fast as the data grows."
+      description="An algorithm is a step-by-step recipe for solving a problem. Analysis is just asking: will this recipe still be fast when the data gets big?"
     >
       <TableOfContents numbered>
-        <Section title="What is an Algorithm?">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="What's an Algorithm?">
           <Typography variant="body2" paragraph>
-            An <strong>algorithm</strong> is just a precise list of steps for getting something done — like a <em>cooking recipe</em> or the <em>directions</em> to a friend&apos;s house. Given the same starting ingredients, it always produces the same result.
+            An <strong>algorithm</strong> is nothing fancy — it&apos;s just a precise list of steps for getting something done. A cooking recipe is an algorithm. So are the directions to a friend&apos;s house. Follow the same steps with the same input, and you always get the same result.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              A Good Algorithm Is...
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2"><strong>✅ Correct:</strong> it produces the right answer every time</Typography>
-              <Typography variant="body2"><strong>📋 Clear:</strong> each step is unambiguous</Typography>
-              <Typography variant="body2"><strong>🏁 Finite:</strong> it eventually stops</Typography>
-              <Typography variant="body2"><strong>⚡ Efficient:</strong> it doesn&apos;t waste time or memory</Typography>
-            </Box>
-          </ConceptInfoCard>
-        </Section>
+          <div className="ds-viz">
+            <div className="illus-label">A recipe is an algorithm — a clear sequence of steps:</div>
+            <div className="flow">
+              <span className="flow-step">Boil water</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step">Add pasta</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step">Wait 10 min</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step">Drain</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>🍝 Done</span>
+            </div>
+          </div>
 
-        <Section title="Why We Measure with Big-O">
-          <Typography variant="body2" paragraph>
-            We don&apos;t measure algorithms in <em>seconds</em>, because that depends on your computer. Instead we count <strong>how the number of steps grows as the input gets bigger</strong>. That growth rate is written with <strong>Big-O notation</strong>.
-          </Typography>
-          <Typography variant="body2" paragraph>
-            The real question Big-O answers is: <em>&quot;If I give this algorithm 10× more data, does it get a little slower, or a lot slower?&quot;</em>
-          </Typography>
-
-          <Alert severity="info">
+          <CalloutBox title="In plain English" type="info" icon="💡">
             <Typography variant="body2">
-              Big-O describes the <strong>worst case</strong> and ignores constants. We care about the <em>shape</em> of the growth, not the exact step count.
+              <strong>Algorithm</strong> = a clear set of steps that takes some input and produces a result. <strong>Analysis</strong> = figuring out how much time and memory those steps need as the input grows.
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="What Makes an Algorithm Good?">
+          <CalloutBox title="A good algorithm is..." type="key-concepts" icon="⭐">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>✅ Correct</strong> — it gives the right answer every time.</Typography>
+              <Typography variant="body2"><strong>📋 Clear</strong> — each step is unambiguous; there&apos;s no guessing.</Typography>
+              <Typography variant="body2"><strong>🏁 Finite</strong> — it always eventually stops (no running forever).</Typography>
+              <Typography variant="body2"><strong>⚡ Efficient</strong> — it doesn&apos;t waste time or memory.</Typography>
+            </Box>
+          </CalloutBox>
+        </Section>
+
+        {/* 3 ----------------------------------------------------------------- */}
+        <Section title="Measuring Speed Without a Stopwatch">
+          <Typography variant="body2" paragraph>
+            How do we say one algorithm is &quot;faster&quot; than another? Not in <em>seconds</em> — that depends on your computer, what else it&apos;s running, even the weather in the data center. Instead, we count <strong>how the number of steps grows as the input gets bigger</strong>.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            The real question we&apos;re answering is simple:
+          </Typography>
+
+          <CalloutBox title="The one question Big-O answers" type="info" icon="📈">
+            <Typography variant="body2">
+              <em>&quot;If I give this algorithm 10× more data, does it get a little slower, or a LOT slower?&quot;</em>
+            </Typography>
+          </CalloutBox>
+
+          <Typography variant="body2" paragraph sx={{ mt: 2 }}>
+            That growth rate gets a shorthand label called <strong>Big-O notation</strong>, written like <code>O(n)</code> or <code>O(n²)</code>. Don&apos;t let the symbols scare you — each one is just a nickname for a <em>shape</em> of growth, which you can see below.
+          </Typography>
+        </Section>
+
+        {/* 4 ----------------------------------------------------------------- */}
         <Section title="See How They Grow">
           <Typography variant="body2" paragraph>
-            Drag the slider to change the input size <strong>n</strong> and watch how many steps each kind of algorithm needs. Notice how <code>O(1)</code> barely moves while <code>O(n²)</code> explodes.
+            Drag the slider to change the input size <strong>n</strong>. Watch how many steps each kind of algorithm needs — <code>O(1)</code> barely moves while <code>O(n²)</code> shoots up.
           </Typography>
 
           <div className="ds-viz">
@@ -81,85 +109,101 @@ export default function AlgorithmAnalysisConcept() {
               <Typography variant="body2" gutterBottom>
                 Input size <strong>n = {n}</strong>
               </Typography>
-              <Slider
-                value={n}
-                min={1}
-                max={64}
-                onChange={(_, v) => setN(v as number)}
-                valueLabelDisplay="auto"
-              />
+              <Slider value={n} min={1} max={64} onChange={(_, v) => setN(v as number)} valueLabelDisplay="auto" />
             </Box>
 
             {results.map((r) => (
               <div className="bigo-row" key={r.label}>
                 <span className="bigo-label" style={{ color: r.color }}>{r.label}</span>
                 <span className="bigo-track">
-                  <span
-                    className="bigo-fill"
-                    style={{
-                      width: `${Math.max(2, (r.value / max) * 100)}%`,
-                      background: r.color,
-                    }}
-                  >
+                  <span className="bigo-fill" style={{ width: `${Math.max(2, (r.value / max) * 100)}%`, background: r.color }}>
                     {r.value <= 9999 ? r.value : '9999+'}
                   </span>
                 </span>
                 <span className="bigo-steps">steps</span>
               </div>
             ))}
-            <p className="ds-caption">Bars are scaled to the slowest algorithm. The number is the actual step count.</p>
+            <p className="ds-caption">Bars are scaled to the slowest one. The number is the actual step count for that input size.</p>
           </div>
+
+          <CalloutBox title="Try this" type="success" icon="🧪">
+            <Typography variant="body2">
+              Slide n up to 64. Notice that <code>O(1)</code> still needs just 1 step, <code>O(log n)</code> only 6, but <code>O(n²)</code> needs over 4,000. That gap is the whole reason we care about analysis.
+            </Typography>
+          </CalloutBox>
         </Section>
 
-        <Section title="Common Complexities (with Analogies)">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Typography variant="body2">
-                <strong style={{ color: '#22c55e' }}>O(1) — Constant:</strong> grabbing the first item in a list. Instant, no matter how long the list is.
-              </Typography>
-              <Typography variant="body2">
-                <strong style={{ color: '#14b8a6' }}>O(log n) — Logarithmic:</strong> finding a word in a dictionary by repeatedly splitting it in half.
-              </Typography>
-              <Typography variant="body2">
-                <strong style={{ color: '#3b82f6' }}>O(n) — Linear:</strong> reading every page of a book once.
-              </Typography>
-              <Typography variant="body2">
-                <strong style={{ color: '#f59e0b' }}>O(n log n) — Linearithmic:</strong> the speed of efficient sorting like merge sort.
-              </Typography>
-              <Typography variant="body2">
-                <strong style={{ color: '#ef4444' }}>O(n²) — Quadratic:</strong> comparing every person in a room with every other person (handshakes).
-              </Typography>
-            </Box>
-          </ConceptInfoCard>
-        </Section>
-
-        <Section title="Designing Algorithms">
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="The Common Speeds, in Plain English">
           <Typography variant="body2" paragraph>
-            <strong>Design</strong> is choosing a strategy to attack a problem. A few classic approaches:
+            You&apos;ll meet these handful of growth shapes again and again. Here they are from fastest to slowest, each with an everyday picture:
           </Typography>
 
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Typography variant="body2">
-                <strong>💪 Brute force:</strong> try every possibility. Simple, but often slow — the &quot;just check everything&quot; approach.
-              </Typography>
-              <Typography variant="body2">
-                <strong>✂️ Divide &amp; conquer:</strong> break the problem into smaller pieces, solve each, and combine. Powers binary search and merge sort.
-              </Typography>
-              <Typography variant="body2">
-                <strong>🪙 Greedy:</strong> make the best-looking choice at each step. Great for things like making change with the fewest coins.
-              </Typography>
-              <Typography variant="body2">
-                <strong>🧠 Dynamic programming:</strong> remember answers to sub-problems so you never solve the same one twice.
-              </Typography>
-            </Box>
-          </ConceptInfoCard>
+          <div className="ds-viz">
+            {COMPLEXITIES.map((c) => (
+              <Box key={c.label} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, mb: 1.75 }}>
+                <span
+                  style={{
+                    flexShrink: 0,
+                    background: c.color,
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontWeight: 700,
+                    fontSize: 13,
+                    padding: '4px 10px',
+                    borderRadius: 6,
+                    minWidth: 92,
+                    textAlign: 'center',
+                  }}
+                >
+                  {c.label}
+                </span>
+                <Typography variant="body2">
+                  <strong>{c.plain}.</strong> {c.analogy}
+                </Typography>
+              </Box>
+            ))}
+          </div>
 
-          <Alert severity="info" sx={{ mt: 2 }}>
+          <CalloutBox title="The two you'll hear most" type="key-concepts" icon="🎯">
             <Typography variant="body2">
-              The data structure you choose is part of the design. The right structure (a stack, queue, or tree) can turn a slow <code>O(n²)</code> idea into a fast <code>O(n log n)</code> one.
+              <strong>O(n log n)</strong> is the target speed for good sorting. <strong>O(n²)</strong> is the warning sign that you&apos;re probably comparing everything to everything — usually a hint there&apos;s a faster way.
             </Typography>
-          </Alert>
+          </CalloutBox>
+        </Section>
+
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="How Programmers Design Algorithms">
+          <Typography variant="body2" paragraph>
+            <strong>Design</strong> is choosing a strategy to attack a problem before you write any code. A few classic game plans:
+          </Typography>
+
+          <CalloutBox title="Common strategies" type="guide" icon="🧩">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1 }}>
+              <Typography variant="body2"><strong>💪 Brute force:</strong> just try every possibility. Simple to write, but often slow.</Typography>
+              <Typography variant="body2"><strong>✂️ Divide &amp; conquer:</strong> break the problem into smaller pieces, solve each, then combine. Powers binary search and merge sort.</Typography>
+              <Typography variant="body2"><strong>🪙 Greedy:</strong> grab the best-looking option at each step. Great for things like making change with the fewest coins.</Typography>
+              <Typography variant="body2"><strong>🧠 Dynamic programming:</strong> remember the answers to sub-problems so you never solve the same one twice.</Typography>
+            </Box>
+          </CalloutBox>
+
+          <CalloutBox title="Data structures are part of the design" type="info" icon="🏗️">
+            <Typography variant="body2">
+              Picking the right structure — a stack, a queue, a tree — can turn a slow <code>O(n²)</code> idea into a fast <code>O(n log n)</code> one. The structure and the algorithm are a team.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 7 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Remember these" type="success" icon="✅">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>An algorithm</strong> is a precise recipe of steps to solve a problem.</Typography>
+              <Typography variant="body2"><strong>Big-O</strong> describes how the work grows as the input grows — not exact seconds.</Typography>
+              <Typography variant="body2"><strong>Faster shapes</strong> (O(1), O(log n), O(n log n)) scale to big data; <strong>O(n²)</strong> doesn&apos;t.</Typography>
+              <Typography variant="body2"><strong>Good design</strong> picks the right strategy and the right data structure together.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
+++ b/components/pageComponents/Python/AlgorithmAnalysisConcept.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
+import Button from '@mui/material/Button';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import CalloutBox from '../../common/CalloutBox';
@@ -19,15 +20,27 @@ type Complexity = {
 };
 
 const COMPLEXITIES: Complexity[] = [
-  { label: 'O(1)', plain: 'Constant', color: '#22c55e', steps: () => 1, analogy: 'Grabbing the first item in a list — instant, no matter how long the list is.' },
+  { label: 'O(1)', plain: 'Constant', color: '#22c55e', steps: () => 1, analogy: 'Retrieving the first item in a list — instant, regardless of list length.' },
   { label: 'O(log n)', plain: 'Logarithmic', color: '#14b8a6', steps: (n) => Math.max(1, Math.ceil(Math.log2(n))), analogy: 'Finding a word in a dictionary by repeatedly splitting it in half.' },
   { label: 'O(n)', plain: 'Linear', color: '#3b82f6', steps: (n) => n, analogy: 'Reading every page of a book once.' },
-  { label: 'O(n log n)', plain: 'Linearithmic', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), analogy: 'The speed of the good sorting algorithms real programs use.' },
-  { label: 'O(n²)', plain: 'Quadratic', color: '#ef4444', steps: (n) => n * n, analogy: 'Everyone in a room shaking hands with everyone else.' },
+  { label: 'O(n log n)', plain: 'Linearithmic', color: '#f59e0b', steps: (n) => Math.max(1, Math.round(n * Math.log2(Math.max(2, n)))), analogy: 'The growth rate of the efficient sorting algorithms used in production.' },
+  { label: 'O(n²)', plain: 'Quadratic', color: '#ef4444', steps: (n) => n * n, analogy: 'Every person in a room shaking hands with every other person.' },
 ];
+
+const SCALE_PRESETS = [
+  { label: '10', value: 10 },
+  { label: '100', value: 100 },
+  { label: '10,000', value: 10000 },
+  { label: '1,000,000', value: 1000000 },
+];
+
+function fmt(x: number): string {
+  return Math.round(x).toLocaleString();
+}
 
 export default function AlgorithmAnalysisConcept() {
   const [n, setN] = useState(16);
+  const [scaleN, setScaleN] = useState(100);
 
   const results = COMPLEXITIES.map((c) => ({ ...c, value: c.steps(n) }));
   const max = Math.max(...results.map((r) => r.value));
@@ -35,45 +48,45 @@ export default function AlgorithmAnalysisConcept() {
   return (
     <ConceptWrapper
       title="Algorithm Analysis & Design"
-      description="An algorithm is a step-by-step recipe for solving a problem. Analysis is just asking: will this recipe still be fast when the data gets big?"
+      description="An algorithm is a step-by-step procedure for solving a problem. Analysis asks a single practical question: will this procedure remain fast as the data grows?"
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
-        <Section title="What's an Algorithm?">
+        <Section title="What Is an Algorithm?">
           <Typography variant="body2" paragraph>
-            An <strong>algorithm</strong> is nothing fancy — it&apos;s just a precise list of steps for getting something done. A cooking recipe is an algorithm. So are the directions to a friend&apos;s house. Follow the same steps with the same input, and you always get the same result.
+            An <strong>algorithm</strong> is simply a precise sequence of steps for accomplishing a task. A cooking recipe is an algorithm, and so are driving directions. Given the same input, following the same steps always produces the same result.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">A recipe is an algorithm — a clear sequence of steps:</div>
+            <div className="illus-label">A recipe is an algorithm — a clear, ordered sequence of steps:</div>
             <div className="flow">
               <span className="flow-step">Boil water</span>
-              <span className="flow-arrow">→</span>
+              <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">Add pasta</span>
-              <span className="flow-arrow">→</span>
-              <span className="flow-step">Wait 10 min</span>
-              <span className="flow-arrow">→</span>
+              <span className="flow-arrow">&rarr;</span>
+              <span className="flow-step">Wait 10 minutes</span>
+              <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">Drain</span>
-              <span className="flow-arrow">→</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>🍝 Done</span>
+              <span className="flow-arrow">&rarr;</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>Done</span>
             </div>
           </div>
 
-          <CalloutBox title="In plain English" type="info" icon="💡">
+          <CalloutBox title="Definition" type="info">
             <Typography variant="body2">
-              <strong>Algorithm</strong> = a clear set of steps that takes some input and produces a result. <strong>Analysis</strong> = figuring out how much time and memory those steps need as the input grows.
+              An <strong>algorithm</strong> takes some input and produces a result through a defined set of steps. <strong>Analysis</strong> is the study of how much time and memory those steps require as the input grows.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
         <Section title="What Makes an Algorithm Good?">
-          <CalloutBox title="A good algorithm is..." type="key-concepts" icon="⭐">
+          <CalloutBox title="The qualities of a good algorithm" type="key-concepts">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>✅ Correct</strong> — it gives the right answer every time.</Typography>
-              <Typography variant="body2"><strong>📋 Clear</strong> — each step is unambiguous; there&apos;s no guessing.</Typography>
-              <Typography variant="body2"><strong>🏁 Finite</strong> — it always eventually stops (no running forever).</Typography>
-              <Typography variant="body2"><strong>⚡ Efficient</strong> — it doesn&apos;t waste time or memory.</Typography>
+              <Typography variant="body2"><strong>Correct</strong> — it produces the right result every time.</Typography>
+              <Typography variant="body2"><strong>Clear</strong> — each step is unambiguous.</Typography>
+              <Typography variant="body2"><strong>Finite</strong> — it always terminates rather than running forever.</Typography>
+              <Typography variant="body2"><strong>Efficient</strong> — it avoids wasting time and memory.</Typography>
             </Box>
           </CalloutBox>
         </Section>
@@ -81,27 +94,27 @@ export default function AlgorithmAnalysisConcept() {
         {/* 3 ----------------------------------------------------------------- */}
         <Section title="Measuring Speed Without a Stopwatch">
           <Typography variant="body2" paragraph>
-            How do we say one algorithm is &quot;faster&quot; than another? Not in <em>seconds</em> — that depends on your computer, what else it&apos;s running, even the weather in the data center. Instead, we count <strong>how the number of steps grows as the input gets bigger</strong>.
+            How do we say one algorithm is faster than another? Not in seconds — that depends on the specific machine, what else it is running, and many other factors. Instead, we measure <strong>how the number of steps grows as the input grows</strong>.
           </Typography>
           <Typography variant="body2" paragraph>
-            The real question we&apos;re answering is simple:
+            The question this answers is straightforward:
           </Typography>
 
-          <CalloutBox title="The one question Big-O answers" type="info" icon="📈">
+          <CalloutBox title="The central question of analysis" type="info">
             <Typography variant="body2">
-              <em>&quot;If I give this algorithm 10× more data, does it get a little slower, or a LOT slower?&quot;</em>
+              If the input becomes ten times larger, does the algorithm become slightly slower, or dramatically slower?
             </Typography>
           </CalloutBox>
 
           <Typography variant="body2" paragraph sx={{ mt: 2 }}>
-            That growth rate gets a shorthand label called <strong>Big-O notation</strong>, written like <code>O(n)</code> or <code>O(n²)</code>. Don&apos;t let the symbols scare you — each one is just a nickname for a <em>shape</em> of growth, which you can see below.
+            That growth rate is given a shorthand label called <strong>Big-O notation</strong>, written as <code>O(n)</code>, <code>O(n²)</code>, and so on. Each label is simply a name for a <em>shape</em> of growth, which the visualizations below make concrete.
           </Typography>
         </Section>
 
         {/* 4 ----------------------------------------------------------------- */}
-        <Section title="See How They Grow">
+        <Section title="Compare the Growth Shapes">
           <Typography variant="body2" paragraph>
-            Drag the slider to change the input size <strong>n</strong>. Watch how many steps each kind of algorithm needs — <code>O(1)</code> barely moves while <code>O(n²)</code> shoots up.
+            Adjust the input size <strong>n</strong> with the slider and observe how many steps each growth rate requires. Notice that <code>O(1)</code> stays flat while <code>O(n²)</code> climbs steeply.
           </Typography>
 
           <div className="ds-viz">
@@ -117,26 +130,74 @@ export default function AlgorithmAnalysisConcept() {
                 <span className="bigo-label" style={{ color: r.color }}>{r.label}</span>
                 <span className="bigo-track">
                   <span className="bigo-fill" style={{ width: `${Math.max(2, (r.value / max) * 100)}%`, background: r.color }}>
-                    {r.value <= 9999 ? r.value : '9999+'}
+                    {fmt(r.value)}
                   </span>
                 </span>
                 <span className="bigo-steps">steps</span>
               </div>
             ))}
-            <p className="ds-caption">Bars are scaled to the slowest one. The number is the actual step count for that input size.</p>
+            <p className="ds-caption">Bars are scaled to the largest value. The number is the actual step count at this input size.</p>
+          </div>
+        </Section>
+
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="The Same Comparison at Scale">
+          <Typography variant="body2" paragraph>
+            Growth shapes only reveal their importance with large inputs. Choose an input size to see the exact number of steps each growth rate would require.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="chip-row" style={{ marginBottom: 16 }}>
+              {SCALE_PRESETS.map((p) => (
+                <button
+                  key={p.value}
+                  className={`select-chip ${scaleN === p.value ? 'selected' : ''}`}
+                  onClick={() => setScaleN(p.value)}
+                >
+                  n = {p.label}
+                </button>
+              ))}
+            </div>
+
+            {COMPLEXITIES.map((c) => (
+              <Box key={c.label} sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
+                <span
+                  style={{
+                    flexShrink: 0,
+                    background: c.color,
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontWeight: 700,
+                    fontSize: 13,
+                    padding: '4px 10px',
+                    borderRadius: 6,
+                    minWidth: 92,
+                    textAlign: 'center',
+                  }}
+                >
+                  {c.label}
+                </span>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                  {fmt(c.steps(scaleN))} steps
+                </Typography>
+              </Box>
+            ))}
+            <p className="ds-caption">
+              At n = {scaleN.toLocaleString()}, the gap between O(log n) and O(n²) is the difference between instant and unusable.
+            </p>
           </div>
 
-          <CalloutBox title="Try this" type="success" icon="🧪">
+          <CalloutBox title="Why this matters" type="success">
             <Typography variant="body2">
-              Slide n up to 64. Notice that <code>O(1)</code> still needs just 1 step, <code>O(log n)</code> only 6, but <code>O(n²)</code> needs over 4,000. That gap is the whole reason we care about analysis.
+              At one million items, an O(log n) algorithm needs about 20 steps while an O(n²) algorithm needs a trillion. This is precisely why algorithm analysis drives real engineering decisions.
             </Typography>
           </CalloutBox>
         </Section>
 
-        {/* 5 ----------------------------------------------------------------- */}
-        <Section title="The Common Speeds, in Plain English">
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="The Common Growth Rates">
           <Typography variant="body2" paragraph>
-            You&apos;ll meet these handful of growth shapes again and again. Here they are from fastest to slowest, each with an everyday picture:
+            A small set of growth rates covers most situations. Listed from fastest to slowest, each with an everyday analogy:
           </Typography>
 
           <div className="ds-viz">
@@ -165,43 +226,43 @@ export default function AlgorithmAnalysisConcept() {
             ))}
           </div>
 
-          <CalloutBox title="The two you'll hear most" type="key-concepts" icon="🎯">
+          <CalloutBox title="The two you will encounter most" type="key-concepts">
             <Typography variant="body2">
-              <strong>O(n log n)</strong> is the target speed for good sorting. <strong>O(n²)</strong> is the warning sign that you&apos;re probably comparing everything to everything — usually a hint there&apos;s a faster way.
-            </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 6 ----------------------------------------------------------------- */}
-        <Section title="How Programmers Design Algorithms">
-          <Typography variant="body2" paragraph>
-            <strong>Design</strong> is choosing a strategy to attack a problem before you write any code. A few classic game plans:
-          </Typography>
-
-          <CalloutBox title="Common strategies" type="guide" icon="🧩">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1 }}>
-              <Typography variant="body2"><strong>💪 Brute force:</strong> just try every possibility. Simple to write, but often slow.</Typography>
-              <Typography variant="body2"><strong>✂️ Divide &amp; conquer:</strong> break the problem into smaller pieces, solve each, then combine. Powers binary search and merge sort.</Typography>
-              <Typography variant="body2"><strong>🪙 Greedy:</strong> grab the best-looking option at each step. Great for things like making change with the fewest coins.</Typography>
-              <Typography variant="body2"><strong>🧠 Dynamic programming:</strong> remember the answers to sub-problems so you never solve the same one twice.</Typography>
-            </Box>
-          </CalloutBox>
-
-          <CalloutBox title="Data structures are part of the design" type="info" icon="🏗️">
-            <Typography variant="body2">
-              Picking the right structure — a stack, a queue, a tree — can turn a slow <code>O(n²)</code> idea into a fast <code>O(n log n)</code> one. The structure and the algorithm are a team.
+              <strong>O(n log n)</strong> is the target growth rate for good sorting. <strong>O(n²)</strong> is a warning sign that an algorithm is likely comparing everything to everything — usually an indication that a faster approach exists.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 7 ----------------------------------------------------------------- */}
+        <Section title="Designing Algorithms">
+          <Typography variant="body2" paragraph>
+            <strong>Design</strong> is the act of choosing a strategy before writing code. Several classic approaches recur across many problems:
+          </Typography>
+
+          <CalloutBox title="Common design strategies" type="guide">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1 }}>
+              <Typography variant="body2"><strong>Brute force:</strong> try every possibility. Simple to implement, but often slow.</Typography>
+              <Typography variant="body2"><strong>Divide and conquer:</strong> break the problem into smaller pieces, solve each, then combine. Powers binary search and merge sort.</Typography>
+              <Typography variant="body2"><strong>Greedy:</strong> take the best-looking option at each step. Effective for problems such as making change with the fewest coins.</Typography>
+              <Typography variant="body2"><strong>Dynamic programming:</strong> store the answers to sub-problems so none is ever solved twice.</Typography>
+            </Box>
+          </CalloutBox>
+
+          <CalloutBox title="Data structures are part of the design" type="info">
+            <Typography variant="body2">
+              Choosing the right structure — a stack, a queue, or a tree — can convert a slow O(n²) approach into a fast O(n log n) one. The structure and the algorithm work together.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 8 ----------------------------------------------------------------- */}
         <Section title="Key Takeaways">
-          <CalloutBox title="Remember these" type="success" icon="✅">
+          <CalloutBox title="Summary" type="success">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>An algorithm</strong> is a precise recipe of steps to solve a problem.</Typography>
-              <Typography variant="body2"><strong>Big-O</strong> describes how the work grows as the input grows — not exact seconds.</Typography>
-              <Typography variant="body2"><strong>Faster shapes</strong> (O(1), O(log n), O(n log n)) scale to big data; <strong>O(n²)</strong> doesn&apos;t.</Typography>
-              <Typography variant="body2"><strong>Good design</strong> picks the right strategy and the right data structure together.</Typography>
+              <Typography variant="body2"><strong>An algorithm</strong> is a precise sequence of steps for solving a problem.</Typography>
+              <Typography variant="body2"><strong>Big-O</strong> describes how work grows as the input grows, independent of any specific machine.</Typography>
+              <Typography variant="body2"><strong>Efficient growth rates</strong> (O(1), O(log n), O(n log n)) scale to large data; O(n²) does not.</Typography>
+              <Typography variant="body2"><strong>Good design</strong> pairs the right strategy with the right data structure.</Typography>
             </Box>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/AttributesMethodsConcept.tsx
+++ b/components/pageComponents/Python/AttributesMethodsConcept.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import CodeSnippet from '../../common/CodeSnippet';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function AttributesMethodsConcept() {
+  const methodCode = [
+    'class BankAccount:',
+    '    def __init__(self, owner, balance=0):',
+    '        self.owner = owner',
+    '        self.balance = balance',
+    '',
+    '    def deposit(self, amount):',
+    '        self.balance += amount',
+    '        return self.balance',
+    '',
+    '    def describe(self):',
+    '        return f"{self.owner} has ${self.balance}"',
+    '',
+    'account = BankAccount("Alice", 100)',
+    'account.deposit(50)',
+    'print(account.describe())   # Alice has $150'
+  ];
+
+  const methodSteps = [
+    {
+      label: 'Set Up Attributes',
+      desc: 'The constructor stores owner and balance on the object',
+      highlight: ['        self.owner = owner', '        self.balance = balance']
+    },
+    {
+      label: 'Define a Method',
+      desc: 'deposit is a behavior the object can perform',
+      highlight: '    def deposit(self, amount):'
+    },
+    {
+      label: 'Change the Data',
+      desc: 'The method updates the object\'s own balance attribute',
+      highlight: '        self.balance += amount'
+    },
+    {
+      label: 'Another Method',
+      desc: 'describe reads the attributes and builds a sentence',
+      highlight: '        return f"{self.owner} has ${self.balance}"'
+    },
+    {
+      label: 'Create the Object',
+      desc: 'Start Alice off with a balance of 100',
+      highlight: 'account = BankAccount("Alice", 100)'
+    },
+    {
+      label: 'Call a Method',
+      desc: 'Calling deposit changes the object and adds 50',
+      highlight: 'account.deposit(50)'
+    },
+    {
+      label: 'See the Result',
+      desc: 'The balance is now 150',
+      highlight: 'print(account.describe())   # Alice has $150'
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Attributes & Methods"
+      description="Objects hold data in attributes and perform actions through methods. Learn how the constructor wires them together."
+    >
+      <TableOfContents numbered>
+        <Section title="Attributes: An Object's Data">
+          <Typography variant="body2" paragraph>
+            <strong>Attributes</strong> are the variables that belong to an object. They store the object&apos;s state — the facts that make one object different from another. A dog&apos;s <code>name</code> and <code>breed</code> are attributes.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Two Kinds of Attributes
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>Instance attributes</strong> belong to one specific object. Each object gets its own copy. Defined with <code>self.x = ...</code> inside a method.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Class attributes</strong> are shared by every object of the class. Defined directly inside the class body, outside any method.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class Dog:' },
+              { code: '    species = "Canis familiaris"   # class attribute (shared)' },
+              { code: '' },
+              { code: '    def __init__(self, name):' },
+              { code: '        self.name = name           # instance attribute (per object)' },
+              { code: '' },
+              { code: 'a = Dog("Buddy")' },
+              { code: 'b = Dog("Rex")' },
+              { code: 'print(a.name, b.name)       # Buddy Rex   (different)' },
+              { code: 'print(a.species, b.species) # same value for both' }
+            ]}
+          />
+        </Section>
+
+        <Section title="The Constructor: __init__">
+          <Typography variant="body2" paragraph>
+            The <code>__init__</code> method is the <strong>constructor</strong>. Python calls it automatically every time you create a new object, which makes it the perfect place to set up the object&apos;s starting attributes.
+          </Typography>
+
+          <CodePartsExplanation
+            code={`class Person:
+    def __init__(self, name, age=0):
+        self.name = name
+        self.age = age
+
+p = Person("Sam", 30)`}
+            parts={[
+              {
+                label: '__init__',
+                part: '__init__',
+                color: '#9333ea',
+                desc: 'The constructor — runs automatically when the object is created'
+              },
+              {
+                label: 'Parameters',
+                part: 'self, name, age=0',
+                color: '#dc2626',
+                desc: 'Values the constructor receives. age has a default of 0'
+              },
+              {
+                label: 'Assigning attributes',
+                part: 'self.name = name',
+                color: '#059669',
+                desc: 'Copies the incoming value onto the object so it persists'
+              },
+              {
+                label: 'Creating the object',
+                part: 'p = Person("Sam", 30)',
+                color: '#2563eb',
+                desc: 'These arguments are passed straight into __init__'
+              }
+            ]}
+          />
+        </Section>
+
+        <Section title="Methods: An Object's Behavior">
+          <Typography variant="body2" paragraph>
+            <strong>Methods</strong> are functions defined inside a class. They describe what an object can <em>do</em>, and they can read or change the object&apos;s attributes through <code>self</code>.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Here a <code>BankAccount</code> stores data in attributes and exposes behavior through methods. Step through to watch the balance change:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={methodCode}
+              steps={methodSteps}
+            />
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The difference between a function and a method is simply <em>where</em> it lives: a method is defined inside a class and almost always takes <code>self</code> as its first parameter.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Dunder Methods (a Quick Peek)">
+          <Typography variant="body2" paragraph>
+            Methods with double underscores on each side — like <code>__init__</code> — are called <strong>dunder</strong> (&quot;double underscore&quot;) methods. Python calls them automatically in special situations. One handy example is <code>__str__</code>, which controls what <code>print()</code> shows.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class Point:' },
+              { code: '    def __init__(self, x, y):' },
+              { code: '        self.x = x' },
+              { code: '        self.y = y' },
+              { code: '' },
+              { code: '    def __str__(self):' },
+              { code: '        return f"Point({self.x}, {self.y})"' },
+              { code: '' },
+              { code: 'p = Point(2, 3)' },
+              { code: 'print(p)   # Point(2, 3)   instead of a messy memory address' }
+            ]}
+          />
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/AttributesMethodsConcept.tsx
+++ b/components/pageComponents/Python/AttributesMethodsConcept.tsx
@@ -1,17 +1,37 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import CodeSnippet from '../../common/CodeSnippet';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type Account = { id: number; owner: string; balance: number };
 
 export default function AttributesMethodsConcept() {
+  const [bankName, setBankName] = useState('PyBank');
+  const [accounts, setAccounts] = useState<Account[]>([
+    { id: 1, owner: 'Alice', balance: 100 },
+    { id: 2, owner: 'Bob', balance: 50 },
+  ]);
+  const [amounts, setAmounts] = useState<Record<number, string>>({ 1: '', 2: '' });
+
+  const deposit = (id: number) => {
+    const a = parseInt(amounts[id], 10);
+    if (isNaN(a) || a <= 0) return;
+    setAccounts((prev) => prev.map((ac) => (ac.id === id ? { ...ac, balance: ac.balance + a } : ac)));
+    setAmounts((prev) => ({ ...prev, [id]: '' }));
+  };
+
   const methodCode = [
     'class BankAccount:',
     '    def __init__(self, owner, balance=0):',
@@ -169,6 +189,53 @@ p = Person("Sam", 30)`}
           <Alert severity="info" sx={{ mt: 2 }}>
             <Typography variant="body2">
               The difference between a function and a method is simply <em>where</em> it lives: a method is defined inside a class and almost always takes <code>self</code> as its first parameter.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Try It Yourself: Instance vs. Class Attributes">
+          <Typography variant="body2" paragraph>
+            Both accounts are built from the same <code>BankAccount</code> class. The <code>bank_name</code> is a <strong>class attribute</strong> shared by every account, while <code>owner</code> and <code>balance</code> are <strong>instance attributes</strong> unique to each one. Change the bank name and watch it update everywhere; deposit into one account and watch the other stay untouched.
+          </Typography>
+
+          <div className="ds-viz">
+            <Box sx={{ mb: 2 }}>
+              <TextField
+                label="BankAccount.bank_name (class attribute)"
+                size="small"
+                value={bankName}
+                onChange={(e) => setBankName(e.target.value)}
+                sx={{ width: 360, maxWidth: '100%' }}
+              />
+            </Box>
+
+            <div className="obj-grid">
+              {accounts.map((ac) => (
+                <div className="obj-card" key={ac.id}>
+                  <div className="obj-card-title">BankAccount instance</div>
+                  <div className="obj-attr"><span className="obj-key">bank_name</span> = &quot;{bankName}&quot;</div>
+                  <div className="obj-attr"><span className="obj-key">owner</span> = &quot;{ac.owner}&quot;</div>
+                  <div className="obj-attr"><span className="obj-key">balance</span> = {ac.balance}</div>
+                  <Box sx={{ display: 'flex', gap: 1, mt: 1.5, alignItems: 'center' }}>
+                    <TextField
+                      label="amount"
+                      type="number"
+                      size="small"
+                      value={amounts[ac.id]}
+                      onChange={(e) => setAmounts((prev) => ({ ...prev, [ac.id]: e.target.value }))}
+                      onKeyDown={(e) => { if (e.key === 'Enter') deposit(ac.id); }}
+                      sx={{ width: 100 }}
+                    />
+                    <Button size="small" variant="outlined" onClick={() => deposit(ac.id)}>deposit()</Button>
+                  </Box>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The shared <code>bank_name</code> changes on both cards at once because it belongs to the class. Each <code>balance</code> changes independently because it belongs to the individual object.
             </Typography>
           </Alert>
         </Section>

--- a/components/pageComponents/Python/ClassesObjectsConcept.tsx
+++ b/components/pageComponents/Python/ClassesObjectsConcept.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function ClassesObjectsConcept() {
+  const classDefinitionCode = [
+    'class Dog:',
+    '    def __init__(self, name, breed):',
+    '        self.name = name',
+    '        self.breed = breed',
+    '',
+    '# Create two objects (instances) of the Dog class',
+    'buddy = Dog("Buddy", "Golden Retriever")',
+    'rex = Dog("Rex", "German Shepherd")',
+    '',
+    'print(buddy.name)   # Buddy',
+    'print(rex.breed)    # German Shepherd'
+  ];
+
+  const classDefinitionSteps = [
+    {
+      label: 'Define the Class',
+      desc: 'Use the "class" keyword to create a blueprint named Dog',
+      highlight: 'class Dog:'
+    },
+    {
+      label: 'The Constructor',
+      desc: '__init__ runs automatically whenever a new Dog is created',
+      highlight: '    def __init__(self, name, breed):'
+    },
+    {
+      label: 'Store the Data',
+      desc: 'Save the name and breed onto this specific object using self',
+      highlight: ['        self.name = name', '        self.breed = breed']
+    },
+    {
+      label: 'Create an Object',
+      desc: 'Calling Dog(...) builds a real dog from the blueprint',
+      highlight: 'buddy = Dog("Buddy", "Golden Retriever")'
+    },
+    {
+      label: 'Make Another One',
+      desc: 'Each object is independent and has its own data',
+      highlight: 'rex = Dog("Rex", "German Shepherd")'
+    },
+    {
+      label: 'Use the Objects',
+      desc: 'Access each object\'s data with dot notation',
+      highlight: ['print(buddy.name)   # Buddy', 'print(rex.breed)    # German Shepherd']
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Classes & Objects"
+      description="Learn the building blocks of Object-Oriented Programming: classes (blueprints) and objects (the things built from them)."
+    >
+      <TableOfContents numbered>
+        <Section title="What is Object-Oriented Programming?">
+          <Typography variant="body2" paragraph>
+            Object-Oriented Programming (OOP) is a way of organizing your code around <strong>objects</strong> instead of just functions and variables. An object bundles together <em>data</em> (what something is) and <em>behavior</em> (what it can do) into a single, self-contained unit.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            It mirrors how we think about the real world. A car has properties (color, speed) and actions (drive, brake). A bank account has a balance and can be deposited into or withdrawn from. OOP lets you model these things directly in code.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Why Use OOP?
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>🧩 Organization:</strong> Group related data and behavior together
+              </Typography>
+              <Typography variant="body2">
+                <strong>🔄 Reusability:</strong> Define a blueprint once, create many objects from it
+              </Typography>
+              <Typography variant="body2">
+                <strong>🛠️ Maintainability:</strong> Change behavior in one place and every object benefits
+              </Typography>
+              <Typography variant="body2">
+                <strong>🌍 Real-world modeling:</strong> Code that maps cleanly onto how we think about problems
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Classes vs. Objects">
+          <Typography variant="body2" paragraph>
+            These two words are at the heart of OOP, and it&apos;s important to keep them straight:
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>📐 A Class is a blueprint.</strong> It describes <em>what</em> something will look like and <em>what</em> it can do, but it isn&apos;t the thing itself. Think of the architectural plan for a house.
+              </Typography>
+              <Typography variant="body2">
+                <strong>🏠 An Object is a real thing built from that blueprint.</strong> It&apos;s a concrete instance with its own actual data. From one house plan you can build many houses, each painted a different color.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              You write the class <strong>once</strong>. You can then create as many objects (also called <strong>instances</strong>) from it as you need.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Defining a Class and Creating Objects">
+          <Typography variant="body2" paragraph>
+            Let&apos;s define a <code>Dog</code> class and use it to create some actual dogs. Hover over each labeled part to see what it does.
+          </Typography>
+
+          <CodePartsExplanation
+            code={`class Dog:
+    def __init__(self, name, breed):
+        self.name = name
+        self.breed = breed
+
+buddy = Dog("Buddy", "Golden Retriever")
+print(buddy.name)`}
+            parts={[
+              {
+                label: 'class keyword',
+                part: 'class Dog:',
+                color: '#9333ea',
+                desc: 'Declares a new class (blueprint) named Dog'
+              },
+              {
+                label: 'Constructor',
+                part: 'def __init__(self, name, breed):',
+                color: '#dc2626',
+                desc: 'A special method that runs when a new object is created'
+              },
+              {
+                label: 'self',
+                part: 'self',
+                color: '#2563eb',
+                desc: 'Refers to the specific object being created or used'
+              },
+              {
+                label: 'Creating an object',
+                part: 'buddy = Dog("Buddy", "Golden Retriever")',
+                color: '#059669',
+                desc: 'Builds a real Dog object and stores it in the variable buddy'
+              }
+            ]}
+          />
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Step through the full example to see how one class produces multiple independent objects:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={classDefinitionCode}
+              steps={classDefinitionSteps}
+            />
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="The self Parameter">
+          <Typography variant="body2" paragraph>
+            You&apos;ll see <code>self</code> everywhere in Python classes. It always refers to <em>the particular object</em> that a method is working on. When you write <code>buddy.name</code>, Python passes <code>buddy</code> in as <code>self</code> behind the scenes.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>self.name</strong> means &quot;the name belonging to <em>this</em> object&quot;
+              </Typography>
+              <Typography variant="body2">
+                Two different dogs each have their own <strong>self.name</strong>, so they never get mixed up
+              </Typography>
+              <Typography variant="body2">
+                Python fills in <strong>self</strong> automatically — you never pass it in yourself when calling a method
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Forgetting <code>self</code> as the first parameter of a method is one of the most common beginner mistakes. Every instance method needs it.
+            </Typography>
+          </Alert>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/ClassesObjectsConcept.tsx
+++ b/components/pageComponents/Python/ClassesObjectsConcept.tsx
@@ -1,16 +1,46 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type DogObject = { id: number; name: string; breed: string };
 
 export default function ClassesObjectsConcept() {
+  const [dogs, setDogs] = useState<DogObject[]>([]);
+  const [dogName, setDogName] = useState('');
+  const [dogBreed, setDogBreed] = useState('');
+  const [nextDogId, setNextDogId] = useState(1);
+  const [barkLog, setBarkLog] = useState<string[]>([]);
+
+  const createDog = () => {
+    const name = dogName.trim() || 'Buddy';
+    const breed = dogBreed.trim() || 'Mixed';
+    setDogs((prev) => [...prev, { id: nextDogId, name, breed }]);
+    setNextDogId((n) => n + 1);
+    setDogName('');
+    setDogBreed('');
+  };
+
+  const bark = (d: DogObject) => {
+    setBarkLog((prev) => [...prev, `${d.name}.bark()  ->  "${d.name} says Woof!"`].slice(-6));
+  };
+
+  const clearAll = () => {
+    setDogs([]);
+    setBarkLog([]);
+  };
+
   const classDefinitionCode = [
     'class Dog:',
     '    def __init__(self, name, breed):',
@@ -78,16 +108,16 @@ export default function ClassesObjectsConcept() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2">
-                <strong>🧩 Organization:</strong> Group related data and behavior together
+                <strong>Organization:</strong> Group related data and behavior together
               </Typography>
               <Typography variant="body2">
-                <strong>🔄 Reusability:</strong> Define a blueprint once, create many objects from it
+                <strong>Reusability:</strong> Define a blueprint once, create many objects from it
               </Typography>
               <Typography variant="body2">
-                <strong>🛠️ Maintainability:</strong> Change behavior in one place and every object benefits
+                <strong>Maintainability:</strong> Change behavior in one place and every object benefits
               </Typography>
               <Typography variant="body2">
-                <strong>🌍 Real-world modeling:</strong> Code that maps cleanly onto how we think about problems
+                <strong>Real-world modeling:</strong> Code that maps cleanly onto how we think about problems
               </Typography>
             </Box>
           </ConceptInfoCard>
@@ -101,10 +131,10 @@ export default function ClassesObjectsConcept() {
           <ConceptInfoCard>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2">
-                <strong>📐 A Class is a blueprint.</strong> It describes <em>what</em> something will look like and <em>what</em> it can do, but it isn&apos;t the thing itself. Think of the architectural plan for a house.
+                <strong>A Class is a blueprint.</strong> It describes <em>what</em> something will look like and <em>what</em> it can do, but it isn&apos;t the thing itself. Think of the architectural plan for a house.
               </Typography>
               <Typography variant="body2">
-                <strong>🏠 An Object is a real thing built from that blueprint.</strong> It&apos;s a concrete instance with its own actual data. From one house plan you can build many houses, each painted a different color.
+                <strong>An Object is a real thing built from that blueprint.</strong> It&apos;s a concrete instance with its own actual data. From one house plan you can build many houses, each painted a different color.
               </Typography>
             </Box>
           </ConceptInfoCard>
@@ -166,6 +196,70 @@ print(buddy.name)`}
               steps={classDefinitionSteps}
             />
           </ConceptInfoCard>
+        </Section>
+
+        <Section title="Try It Yourself: An Object Factory">
+          <Typography variant="body2" paragraph>
+            The <code>Dog</code> class is the blueprint. Fill in a name and breed, then create as many <code>Dog</code> objects as you like. Each one is an independent instance with its own data — and each can run the same <code>bark()</code> method.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="ds-controls">
+              <TextField
+                label="name"
+                size="small"
+                value={dogName}
+                onChange={(e) => setDogName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') createDog(); }}
+                sx={{ width: 160 }}
+              />
+              <TextField
+                label="breed"
+                size="small"
+                value={dogBreed}
+                onChange={(e) => setDogBreed(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') createDog(); }}
+                sx={{ width: 180 }}
+              />
+              <Button variant="contained" onClick={createDog}>Create Dog object</Button>
+              <Button variant="text" color="secondary" onClick={clearAll} disabled={dogs.length === 0}>Clear</Button>
+            </div>
+
+            {dogs.length === 0 ? (
+              <Typography variant="body2" sx={{ color: '#94a3b8', fontStyle: 'italic' }}>
+                No objects yet. Create one from the Dog blueprint above.
+              </Typography>
+            ) : (
+              <div className="obj-grid">
+                {dogs.map((d) => (
+                  <div className="obj-card" key={d.id}>
+                    <div className="obj-card-title">Dog instance</div>
+                    <div className="obj-attr"><span className="obj-key">name</span> = &quot;{d.name}&quot;</div>
+                    <div className="obj-attr"><span className="obj-key">breed</span> = &quot;{d.breed}&quot;</div>
+                    <Button size="small" variant="outlined" sx={{ mt: 1 }} onClick={() => bark(d)}>
+                      call bark()
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="output-panel">
+              {barkLog.length === 0 ? (
+                <span className="muted"># Output of bark() calls will appear here</span>
+              ) : (
+                barkLog.map((line, i) => (
+                  <div key={i}><span className="out-prompt">&gt;&gt;&gt; </span>{line}</div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Notice that every object shares the same blueprint and the same <code>bark()</code> behavior, yet each keeps its own separate <code>name</code> and <code>breed</code>.
+            </Typography>
+          </Alert>
         </Section>
 
         <Section title="The self Parameter">

--- a/components/pageComponents/Python/EncapsulationConcept.tsx
+++ b/components/pageComponents/Python/EncapsulationConcept.tsx
@@ -1,17 +1,57 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import CodeSnippet from '../../common/CodeSnippet';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type LogLine = { text: string; ok: boolean };
 
 export default function EncapsulationConcept() {
+  const [balance, setBalance] = useState(100);
+  const [amount, setAmount] = useState('');
+  const [log, setLog] = useState<LogLine[]>([]);
+
+  const addLog = (text: string, ok: boolean) => setLog((prev) => [...prev, { text, ok }].slice(-6));
+
+  const deposit = () => {
+    const a = parseInt(amount, 10);
+    if (isNaN(a) || a <= 0) {
+      addLog(`deposit(${amount || '?'})  rejected: amount must be positive`, false);
+      return;
+    }
+    setBalance((b) => b + a);
+    addLog(`deposit(${a})  accepted -> balance is now ${balance + a}`, true);
+    setAmount('');
+  };
+
+  const withdraw = () => {
+    const a = parseInt(amount, 10);
+    if (isNaN(a) || a <= 0) {
+      addLog(`withdraw(${amount || '?'})  rejected: amount must be positive`, false);
+      return;
+    }
+    if (a > balance) {
+      addLog(`withdraw(${a})  rejected: cannot exceed balance of ${balance}`, false);
+      return;
+    }
+    setBalance((b) => b - a);
+    addLog(`withdraw(${a})  accepted -> balance is now ${balance - a}`, true);
+    setAmount('');
+  };
+
+  const clearLog = () => setLog([]);
+
   const encapsulationCode = [
     'class BankAccount:',
     '    def __init__(self, balance):',
@@ -84,13 +124,13 @@ export default function EncapsulationConcept() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2">
-                <strong>🛡️ Protect data:</strong> Stop outside code from putting the object in an invalid state
+                <strong>Protect data:</strong> Stop outside code from putting the object in an invalid state
               </Typography>
               <Typography variant="body2">
-                <strong>✅ Validate changes:</strong> Run checks before allowing a value to change
+                <strong>Validate changes:</strong> Run checks before allowing a value to change
               </Typography>
               <Typography variant="body2">
-                <strong>🔌 Stable interface:</strong> Change internals later without breaking other code
+                <strong>Stable interface:</strong> Change internals later without breaking other code
               </Typography>
             </Box>
           </ConceptInfoCard>
@@ -169,6 +209,49 @@ export default function EncapsulationConcept() {
               steps={encapsulationSteps}
             />
           </ConceptInfoCard>
+        </Section>
+
+        <Section title="Try It Yourself: A Guarded Account">
+          <Typography variant="body2" paragraph>
+            The balance is private and can only change through <code>deposit()</code> and <code>withdraw()</code>. Those methods enforce the rules, so the balance can never become negative or change by an invalid amount. Try to break it.
+          </Typography>
+
+          <div className="ds-viz">
+            <Box sx={{ mb: 2, p: 2, borderRadius: 2, bgcolor: '#f0fdf4', border: '1px solid #86efac' }}>
+              <Typography variant="caption" sx={{ color: '#15803d', display: 'block' }}>account.get_balance()</Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, color: '#166534' }}>${balance}</Typography>
+            </Box>
+
+            <div className="ds-controls">
+              <TextField
+                label="amount"
+                type="number"
+                size="small"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                sx={{ width: 150 }}
+              />
+              <Button variant="contained" onClick={deposit}>deposit()</Button>
+              <Button variant="outlined" onClick={withdraw}>withdraw()</Button>
+              <Button variant="text" color="secondary" onClick={clearLog} disabled={log.length === 0}>Clear log</Button>
+            </div>
+
+            <div className="output-panel">
+              {log.length === 0 ? (
+                <span className="muted"># Try depositing a negative number, or withdrawing more than the balance</span>
+              ) : (
+                log.map((line, i) => (
+                  <div key={i} className={line.ok ? 'ok' : 'err'}>{line.ok ? '[ok] ' : '[blocked] '}{line.text}</div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              There is no way to set the balance directly from outside — every change must pass through a method that validates it first. That guarantee is exactly what encapsulation provides.
+            </Typography>
+          </Alert>
         </Section>
 
         <Section title="The Pythonic Way: @property">

--- a/components/pageComponents/Python/EncapsulationConcept.tsx
+++ b/components/pageComponents/Python/EncapsulationConcept.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import CodeSnippet from '../../common/CodeSnippet';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function EncapsulationConcept() {
+  const encapsulationCode = [
+    'class BankAccount:',
+    '    def __init__(self, balance):',
+    '        self.__balance = balance      # private attribute',
+    '',
+    '    def deposit(self, amount):',
+    '        if amount > 0:',
+    '            self.__balance += amount',
+    '',
+    '    def get_balance(self):',
+    '        return self.__balance',
+    '',
+    'acct = BankAccount(100)',
+    'acct.deposit(50)',
+    'print(acct.get_balance())   # 150',
+    'acct.deposit(-999)          # ignored by the rule above',
+    'print(acct.get_balance())   # still 150'
+  ];
+
+  const encapsulationSteps = [
+    {
+      label: 'Hide the Data',
+      desc: 'The double underscore makes __balance private to the class',
+      highlight: '        self.__balance = balance      # private attribute'
+    },
+    {
+      label: 'Guard the Changes',
+      desc: 'deposit checks the amount before touching the balance',
+      highlight: ['    def deposit(self, amount):', '        if amount > 0:']
+    },
+    {
+      label: 'Controlled Access',
+      desc: 'get_balance is the safe, official way to read the balance',
+      highlight: '    def get_balance(self):'
+    },
+    {
+      label: 'Use It Normally',
+      desc: 'A valid deposit passes the check and updates the balance',
+      highlight: 'acct.deposit(50)'
+    },
+    {
+      label: 'Invalid Input Blocked',
+      desc: 'A negative deposit fails the if-check and is ignored',
+      highlight: 'acct.deposit(-999)          # ignored by the rule above'
+    },
+    {
+      label: 'Data Stays Valid',
+      desc: 'The balance could never be corrupted from outside',
+      highlight: 'print(acct.get_balance())   # still 150'
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Encapsulation"
+      description="Bundle data with the methods that protect it, and hide the internal details behind a clean, safe interface."
+    >
+      <TableOfContents numbered>
+        <Section title="What is Encapsulation?">
+          <Typography variant="body2" paragraph>
+            <strong>Encapsulation</strong> means keeping an object&apos;s data and the code that operates on it together, while <em>hiding</em> the internal details from the outside world. Other code interacts with the object only through a controlled set of methods.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            Think of a vending machine. You press buttons (the public interface) — you don&apos;t reach inside to rearrange the mechanics. The machine protects its internals and only lets you do valid operations.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Why Encapsulate?
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>🛡️ Protect data:</strong> Stop outside code from putting the object in an invalid state
+              </Typography>
+              <Typography variant="body2">
+                <strong>✅ Validate changes:</strong> Run checks before allowing a value to change
+              </Typography>
+              <Typography variant="body2">
+                <strong>🔌 Stable interface:</strong> Change internals later without breaking other code
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Public, Protected, and Private">
+          <Typography variant="body2" paragraph>
+            Python signals how &quot;private&quot; an attribute is by convention, using underscores:
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>name</strong> — <em>public.</em> Anyone can read and change it freely.
+              </Typography>
+              <Typography variant="body2">
+                <strong>_name</strong> — <em>protected (by convention).</em> A single underscore says &quot;internal, please don&apos;t touch from outside.&quot; Python doesn&apos;t enforce it.
+              </Typography>
+              <Typography variant="body2">
+                <strong>__name</strong> — <em>private.</em> A double underscore triggers <strong>name mangling</strong>, which makes it hard (on purpose) to access from outside the class.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Python doesn&apos;t have truly enforced private variables like some languages. The underscores are mostly a strong agreement between programmers — but the double underscore makes accidental access much less likely.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="A Protected Bank Account">
+          <Typography variant="body2" paragraph>
+            By making the balance private and only exposing controlled methods, we guarantee the balance can never be set to something invalid:
+          </Typography>
+
+          <CodePartsExplanation
+            code={`class BankAccount:
+    def __init__(self, balance):
+        self.__balance = balance
+
+    def deposit(self, amount):
+        if amount > 0:
+            self.__balance += amount
+
+    def get_balance(self):
+        return self.__balance`}
+            parts={[
+              {
+                label: 'Private attribute',
+                part: 'self.__balance = balance',
+                color: '#dc2626',
+                desc: 'The leading __ hides this value from outside code'
+              },
+              {
+                label: 'Validation',
+                part: 'if amount > 0:',
+                color: '#9333ea',
+                desc: 'A guard that only allows sensible deposits'
+              },
+              {
+                label: 'Getter method',
+                part: 'def get_balance(self):',
+                color: '#059669',
+                desc: 'The safe, read-only way to view the balance'
+              }
+            ]}
+          />
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Step through to see the guard reject bad input:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={encapsulationCode}
+              steps={encapsulationSteps}
+            />
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="The Pythonic Way: @property">
+          <Typography variant="body2" paragraph>
+            Writing <code>get_x()</code> and <code>set_x()</code> methods everywhere gets clunky. Python&apos;s <code>@property</code> decorator lets you guard an attribute while still using clean dot-syntax to access it.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class Temperature:' },
+              { code: '    def __init__(self, celsius):' },
+              { code: '        self._celsius = celsius' },
+              { code: '' },
+              { code: '    @property' },
+              { code: '    def celsius(self):' },
+              { code: '        return self._celsius' },
+              { code: '' },
+              { code: '    @celsius.setter' },
+              { code: '    def celsius(self, value):' },
+              { code: '        if value < -273.15:' },
+              { code: '            raise ValueError("Below absolute zero!")' },
+              { code: '        self._celsius = value' },
+              { code: '' },
+              { code: 't = Temperature(20)' },
+              { code: 't.celsius = 25        # looks like a normal attribute...' },
+              { code: 'print(t.celsius)      # ...but the setter validated it: 25' }
+            ]}
+          />
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              With <code>@property</code>, callers write <code>t.celsius = 25</code> as if it were a plain attribute, but your validation still runs behind the scenes. Best of both worlds.
+            </Typography>
+          </Alert>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/InheritanceConcept.tsx
+++ b/components/pageComponents/Python/InheritanceConcept.tsx
@@ -1,17 +1,45 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import CodeSnippet from '../../common/CodeSnippet';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+const SUBCLASSES: { name: string; sound: string }[] = [
+  { name: 'Dog', sound: 'Woof!' },
+  { name: 'Cat', sound: 'Meow!' },
+  { name: 'Cow', sound: 'Moo!' },
+];
 
 export default function InheritanceConcept() {
+  const [selected, setSelected] = useState('Dog');
+  const [petName, setPetName] = useState('Buddy');
+  const [log, setLog] = useState<string[]>([]);
+
+  const run = () => {
+    const cls = SUBCLASSES.find((c) => c.name === selected)!;
+    const name = petName.trim() || 'Buddy';
+    setLog((prev) => [
+      ...prev,
+      `${selected.toLowerCase()} = ${selected}("${name}")`,
+      `${selected.toLowerCase()}.name      ->  "${name}"   (inherited from Animal)`,
+      `${selected.toLowerCase()}.speak()   ->  "${cls.sound}"   (overridden in ${selected})`,
+      `isinstance(${selected.toLowerCase()}, Animal)  ->  True`,
+    ].slice(-8));
+  };
+
+  const clearLog = () => setLog([]);
+
   const inheritanceCode = [
     'class Animal:',
     '    def __init__(self, name):',
@@ -91,13 +119,13 @@ export default function InheritanceConcept() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2">
-                <strong>♻️ Avoid repetition:</strong> Write shared behavior once in the parent
+                <strong>Avoid repetition:</strong> Write shared behavior once in the parent
               </Typography>
               <Typography variant="body2">
-                <strong>🌳 Model hierarchies:</strong> Express natural &quot;is-a&quot; relationships
+                <strong>Model hierarchies:</strong> Express natural &quot;is-a&quot; relationships
               </Typography>
               <Typography variant="body2">
-                <strong>🔧 Extend safely:</strong> Add or change behavior in a child without touching the parent
+                <strong>Extend safely:</strong> Add or change behavior in a child without touching the parent
               </Typography>
             </Box>
           </ConceptInfoCard>
@@ -147,6 +175,55 @@ class Dog(Animal):
               steps={inheritanceSteps}
             />
           </ConceptInfoCard>
+        </Section>
+
+        <Section title="Try It Yourself: Subclasses in Action">
+          <Typography variant="body2" paragraph>
+            <code>Dog</code>, <code>Cat</code>, and <code>Cow</code> all inherit from <code>Animal</code>. Each one reuses the inherited <code>name</code> attribute but provides its own version of <code>speak()</code>. Pick a subclass, give it a name, and run it.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="chip-row" style={{ marginBottom: 14 }}>
+              {SUBCLASSES.map((c) => (
+                <button
+                  key={c.name}
+                  className={`select-chip ${selected === c.name ? 'selected' : ''}`}
+                  onClick={() => setSelected(c.name)}
+                >
+                  {c.name}(Animal)
+                </button>
+              ))}
+            </div>
+
+            <div className="ds-controls">
+              <TextField
+                label="name"
+                size="small"
+                value={petName}
+                onChange={(e) => setPetName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') run(); }}
+                sx={{ width: 180 }}
+              />
+              <Button variant="contained" onClick={run}>Create &amp; call speak()</Button>
+              <Button variant="text" color="secondary" onClick={clearLog} disabled={log.length === 0}>Clear</Button>
+            </div>
+
+            <div className="output-panel">
+              {log.length === 0 ? (
+                <span className="muted"># Choose a subclass and run it to see inherited vs overridden behavior</span>
+              ) : (
+                log.map((line, i) => (
+                  <div key={i}><span className="out-prompt">&gt;&gt;&gt; </span>{line}</div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The <code>name</code> attribute is the same code inherited from <code>Animal</code>, while <code>speak()</code> changes per subclass. That combination — shared structure, customized behavior — is the heart of inheritance.
+            </Typography>
+          </Alert>
         </Section>
 
         <Section title="Extending the Parent with super()">

--- a/components/pageComponents/Python/InheritanceConcept.tsx
+++ b/components/pageComponents/Python/InheritanceConcept.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import CodeSnippet from '../../common/CodeSnippet';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function InheritanceConcept() {
+  const inheritanceCode = [
+    'class Animal:',
+    '    def __init__(self, name):',
+    '        self.name = name',
+    '',
+    '    def speak(self):',
+    '        return "Some generic sound"',
+    '',
+    'class Dog(Animal):',
+    '    def speak(self):',
+    '        return "Woof!"',
+    '',
+    'class Cat(Animal):',
+    '    def speak(self):',
+    '        return "Meow!"',
+    '',
+    'd = Dog("Buddy")',
+    'print(d.name)      # Buddy   (inherited from Animal)',
+    'print(d.speak())   # Woof!   (overridden in Dog)'
+  ];
+
+  const inheritanceSteps = [
+    {
+      label: 'The Parent Class',
+      desc: 'Animal defines what every animal has and does',
+      highlight: 'class Animal:'
+    },
+    {
+      label: 'Shared Behavior',
+      desc: 'speak provides a default that children can reuse or replace',
+      highlight: '        return "Some generic sound"'
+    },
+    {
+      label: 'A Child Class',
+      desc: 'Dog(Animal) means Dog inherits everything from Animal',
+      highlight: 'class Dog(Animal):'
+    },
+    {
+      label: 'Override a Method',
+      desc: 'Dog provides its own version of speak',
+      highlight: ['class Dog(Animal):', '        return "Woof!"']
+    },
+    {
+      label: 'Another Child',
+      desc: 'Cat also inherits from Animal but speaks differently',
+      highlight: ['class Cat(Animal):', '        return "Meow!"']
+    },
+    {
+      label: 'Inherited Attribute',
+      desc: 'Dog never defined __init__, so it uses Animal\'s — name still works',
+      highlight: 'print(d.name)      # Buddy   (inherited from Animal)'
+    },
+    {
+      label: 'Overridden Method',
+      desc: 'Calling speak on a Dog uses Dog\'s version',
+      highlight: 'print(d.speak())   # Woof!   (overridden in Dog)'
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Inheritance"
+      description="Build new classes on top of existing ones so child classes reuse and extend a parent's behavior."
+    >
+      <TableOfContents numbered>
+        <Section title="What is Inheritance?">
+          <Typography variant="body2" paragraph>
+            <strong>Inheritance</strong> lets one class take on the attributes and methods of another. The class being inherited from is the <strong>parent</strong> (or base/super) class, and the class doing the inheriting is the <strong>child</strong> (or derived/sub) class.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            It models an &quot;is-a&quot; relationship: a Dog <em>is an</em> Animal, a SavingsAccount <em>is a</em> BankAccount. The child automatically gets everything the parent has, so you don&apos;t repeat shared code.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Why Use Inheritance?
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>♻️ Avoid repetition:</strong> Write shared behavior once in the parent
+              </Typography>
+              <Typography variant="body2">
+                <strong>🌳 Model hierarchies:</strong> Express natural &quot;is-a&quot; relationships
+              </Typography>
+              <Typography variant="body2">
+                <strong>🔧 Extend safely:</strong> Add or change behavior in a child without touching the parent
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Creating a Child Class">
+          <Typography variant="body2" paragraph>
+            To inherit, put the parent class name in parentheses after the child class name. Hover the parts below:
+          </Typography>
+
+          <CodePartsExplanation
+            code={`class Animal:
+    def speak(self):
+        return "..."
+
+class Dog(Animal):
+    def speak(self):
+        return "Woof!"`}
+            parts={[
+              {
+                label: 'Parent class',
+                part: 'class Animal:',
+                color: '#9333ea',
+                desc: 'The base class that holds shared behavior'
+              },
+              {
+                label: 'Inheriting',
+                part: 'class Dog(Animal):',
+                color: '#059669',
+                desc: 'Dog inherits everything from Animal by naming it in parentheses'
+              },
+              {
+                label: 'Overriding',
+                part: 'return "Woof!"',
+                color: '#dc2626',
+                desc: 'Dog replaces the inherited speak with its own version'
+              }
+            ]}
+          />
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Step through to see what gets inherited and what gets overridden:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={inheritanceCode}
+              steps={inheritanceSteps}
+            />
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Extending the Parent with super()">
+          <Typography variant="body2" paragraph>
+            Sometimes a child wants to <em>add to</em> the parent&apos;s work rather than replace it entirely. The <code>super()</code> function calls the parent&apos;s version of a method — most often the constructor.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class Animal:' },
+              { code: '    def __init__(self, name):' },
+              { code: '        self.name = name' },
+              { code: '' },
+              { code: 'class Dog(Animal):' },
+              { code: '    def __init__(self, name, breed):' },
+              { code: '        super().__init__(name)   # let Animal set up name' },
+              { code: '        self.breed = breed       # then add Dog-specific data' },
+              { code: '' },
+              { code: 'd = Dog("Buddy", "Beagle")' },
+              { code: 'print(d.name, d.breed)   # Buddy Beagle' }
+            ]}
+          />
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              <code>super().__init__(...)</code> reuses the parent&apos;s setup so you don&apos;t copy/paste it. The child then layers on whatever extra attributes it needs.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Checking Types: isinstance">
+          <Typography variant="body2" paragraph>
+            Because a child &quot;is a&quot; kind of its parent, Python recognizes it as both types. <code>isinstance</code> lets you check this at runtime.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'd = Dog("Buddy", "Beagle")' },
+              { code: '' },
+              { code: 'print(isinstance(d, Dog))      # True' },
+              { code: 'print(isinstance(d, Animal))   # True  (a Dog is also an Animal)' },
+              { code: 'print(isinstance(d, Cat))      # False' }
+            ]}
+          />
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/PolymorphismConcept.tsx
+++ b/components/pageComponents/Python/PolymorphismConcept.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodePartsExplanation from '../../common/CodePartsExplanation';
+import CodeSnippet from '../../common/CodeSnippet';
+import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
+import TableOfContents from '@/components/common/TableOfContents';
+
+export default function PolymorphismConcept() {
+  const polymorphismCode = [
+    'class Dog:',
+    '    def speak(self):',
+    '        return "Woof!"',
+    '',
+    'class Cat:',
+    '    def speak(self):',
+    '        return "Meow!"',
+    '',
+    'class Cow:',
+    '    def speak(self):',
+    '        return "Moo!"',
+    '',
+    '# One loop, many different objects',
+    'for animal in [Dog(), Cat(), Cow()]:',
+    '    print(animal.speak())',
+    '',
+    '# Output:',
+    '# Woof!',
+    '# Meow!',
+    '# Moo!'
+  ];
+
+  const polymorphismSteps = [
+    {
+      label: 'Same Method Name',
+      desc: 'Every animal class defines its own speak method',
+      highlight: ['    def speak(self):']
+    },
+    {
+      label: 'Different Behavior',
+      desc: 'Each speak returns something different',
+      highlight: ['        return "Woof!"', '        return "Meow!"', '        return "Moo!"']
+    },
+    {
+      label: 'One Loop for All',
+      desc: 'The loop doesn\'t care what type each animal is',
+      highlight: 'for animal in [Dog(), Cat(), Cow()]:'
+    },
+    {
+      label: 'The Magic Call',
+      desc: 'animal.speak() runs the right version for each object',
+      highlight: '    print(animal.speak())'
+    }
+  ];
+
+  return (
+    <ConceptWrapper
+      title="Polymorphism"
+      description="Write code that works with many different types through a shared interface — one call, many behaviors."
+    >
+      <TableOfContents numbered>
+        <Section title="What is Polymorphism?">
+          <Typography variant="body2" paragraph>
+            <strong>Polymorphism</strong> means &quot;many forms.&quot; In OOP it&apos;s the idea that different objects can respond to the <em>same</em> method call in their <em>own</em> way. You call <code>speak()</code> and each object does the right thing for its type.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            This is powerful because your code can work with a whole family of objects without knowing or caring exactly which one it&apos;s holding — it just trusts that they all understand the same method.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Why Use Polymorphism?
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>🔁 Less branching:</strong> No long if/elif chains checking the type
+              </Typography>
+              <Typography variant="body2">
+                <strong>➕ Easy to extend:</strong> Add a new type and existing code just works
+              </Typography>
+              <Typography variant="body2">
+                <strong>🧼 Cleaner code:</strong> One uniform way to treat many different objects
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="One Interface, Many Behaviors">
+          <Typography variant="body2" paragraph>
+            Here three unrelated classes all define a <code>speak</code> method. A single loop treats them all the same way:
+          </Typography>
+
+          <CodePartsExplanation
+            code={`for animal in [Dog(), Cat(), Cow()]:
+    print(animal.speak())`}
+            parts={[
+              {
+                label: 'Mixed list',
+                part: '[Dog(), Cat(), Cow()]',
+                color: '#9333ea',
+                desc: 'Objects of three different types in one list'
+              },
+              {
+                label: 'Uniform call',
+                part: 'animal.speak()',
+                color: '#059669',
+                desc: 'The same call works on every object, no type checks needed'
+              }
+            ]}
+          />
+
+          <ConceptInfoCard>
+            <Typography variant="body2" paragraph>
+              Step through to see one call produce three different results:
+            </Typography>
+            <StepThroughCodeAnimation
+              code={polymorphismCode}
+              steps={polymorphismSteps}
+            />
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Duck Typing">
+          <Typography variant="body2" paragraph>
+            Python takes polymorphism a step further with <strong>duck typing</strong>: &quot;If it walks like a duck and quacks like a duck, it&apos;s a duck.&quot; The objects above didn&apos;t even need a shared parent class — Python only cares that each one <em>has</em> a <code>speak</code> method when it&apos;s called.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'def make_it_speak(thing):' },
+              { code: '    # We never check the type — we just trust it has speak()' },
+              { code: '    return thing.speak()' },
+              { code: '' },
+              { code: 'print(make_it_speak(Dog()))   # Woof!' },
+              { code: 'print(make_it_speak(Cat()))   # Meow!' },
+              { code: '' },
+              { code: 'class Robot:' },
+              { code: '    def speak(self):' },
+              { code: '        return "Beep boop"' },
+              { code: '' },
+              { code: 'print(make_it_speak(Robot()))  # Beep boop — works too!' }
+            ]}
+          />
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              A brand-new <code>Robot</code> class slots right in without changing <code>make_it_speak</code> at all. That&apos;s the real payoff of polymorphism.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Polymorphism with Inheritance">
+          <Typography variant="body2" paragraph>
+            Polymorphism often pairs with inheritance: a parent defines a method and each child <em>overrides</em> it. Code written against the parent type automatically gets each child&apos;s behavior.
+          </Typography>
+
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'class Shape:' },
+              { code: '    def area(self):' },
+              { code: '        return 0' },
+              { code: '' },
+              { code: 'class Circle(Shape):' },
+              { code: '    def __init__(self, r):' },
+              { code: '        self.r = r' },
+              { code: '    def area(self):' },
+              { code: '        return 3.14159 * self.r ** 2' },
+              { code: '' },
+              { code: 'class Square(Shape):' },
+              { code: '    def __init__(self, side):' },
+              { code: '        self.side = side' },
+              { code: '    def area(self):' },
+              { code: '        return self.side ** 2' },
+              { code: '' },
+              { code: 'shapes = [Circle(2), Square(3)]' },
+              { code: 'for s in shapes:' },
+              { code: '    print(s.area())   # 12.566... then 9' }
+            ]}
+          />
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/PolymorphismConcept.tsx
+++ b/components/pageComponents/Python/PolymorphismConcept.tsx
@@ -1,17 +1,41 @@
 'use client';
 
+import { useState } from 'react';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import ConceptInfoCard from '../../common/ConceptInfoCard';
 import CodePartsExplanation from '../../common/CodePartsExplanation';
 import CodeSnippet from '../../common/CodeSnippet';
 import StepThroughCodeAnimation from '../JavaScript/StepThroughCodeAnimation';
 import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
 
 export default function PolymorphismConcept() {
+  const [radius, setRadius] = useState(2);
+  const [side, setSide] = useState(3);
+  const [base, setBase] = useState(4);
+  const [height, setHeight] = useState(5);
+  const [output, setOutput] = useState<string[]>([]);
+
+  const runAreas = () => {
+    const circle = Math.PI * radius * radius;
+    const square = side * side;
+    const triangle = 0.5 * base * height;
+    setOutput([
+      'for shape in shapes:',
+      '    print(shape.area())',
+      '',
+      `Circle(r=${radius}).area()    ->  ${circle.toFixed(2)}`,
+      `Square(s=${side}).area()    ->  ${square.toFixed(2)}`,
+      `Triangle(${base}, ${height}).area() ->  ${triangle.toFixed(2)}`,
+    ]);
+  };
+
   const polymorphismCode = [
     'class Dog:',
     '    def speak(self):',
@@ -78,13 +102,13 @@ export default function PolymorphismConcept() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2">
-                <strong>🔁 Less branching:</strong> No long if/elif chains checking the type
+                <strong>Less branching:</strong> No long if/elif chains checking the type
               </Typography>
               <Typography variant="body2">
-                <strong>➕ Easy to extend:</strong> Add a new type and existing code just works
+                <strong>Easy to extend:</strong> Add a new type and existing code just works
               </Typography>
               <Typography variant="body2">
-                <strong>🧼 Cleaner code:</strong> One uniform way to treat many different objects
+                <strong>Cleaner code:</strong> One uniform way to treat many different objects
               </Typography>
             </Box>
           </ConceptInfoCard>
@@ -123,6 +147,51 @@ export default function PolymorphismConcept() {
               steps={polymorphismSteps}
             />
           </ConceptInfoCard>
+        </Section>
+
+        <Section title="Try It Yourself: One Call, Many Shapes">
+          <Typography variant="body2" paragraph>
+            Three different shape classes each define their own <code>area()</code>. Adjust their dimensions, then run a single loop that calls <code>shape.area()</code> on every one — the same call produces a different, correct result for each type.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="shape-row" style={{ marginBottom: 16 }}>
+              <div className="shape-card">
+                <svg width="60" height="60"><circle cx="30" cy="30" r="24" fill="#dbeafe" stroke="#2563eb" strokeWidth="2" /></svg>
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>Circle</Typography>
+                <TextField label="radius" type="number" size="small" value={radius} onChange={(e) => setRadius(Number(e.target.value) || 0)} sx={{ width: 110 }} />
+              </div>
+              <div className="shape-card">
+                <svg width="60" height="60"><rect x="8" y="8" width="44" height="44" rx="4" fill="#dcfce7" stroke="#16a34a" strokeWidth="2" /></svg>
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>Square</Typography>
+                <TextField label="side" type="number" size="small" value={side} onChange={(e) => setSide(Number(e.target.value) || 0)} sx={{ width: 110 }} />
+              </div>
+              <div className="shape-card">
+                <svg width="60" height="60"><polygon points="30,8 52,52 8,52" fill="#fef9c3" stroke="#ca8a04" strokeWidth="2" /></svg>
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>Triangle</Typography>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <TextField label="base" type="number" size="small" value={base} onChange={(e) => setBase(Number(e.target.value) || 0)} sx={{ width: 80 }} />
+                  <TextField label="height" type="number" size="small" value={height} onChange={(e) => setHeight(Number(e.target.value) || 0)} sx={{ width: 80 }} />
+                </Box>
+              </div>
+            </div>
+
+            <Button variant="contained" onClick={runAreas}>Run: shape.area() on every shape</Button>
+
+            <div className="output-panel" style={{ marginTop: 14 }}>
+              {output.length === 0 ? (
+                <span className="muted"># Adjust the dimensions and run the loop</span>
+              ) : (
+                output.map((line, i) => <div key={i}>{line || ' '}</div>)
+              )}
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The loop never checks what type each shape is. It simply trusts that every shape understands <code>area()</code> — that trust is what makes polymorphism so flexible.
+            </Typography>
+          </Alert>
         </Section>
 
         <Section title="Duck Typing">

--- a/components/pageComponents/Python/PythonPage.tsx
+++ b/components/pageComponents/Python/PythonPage.tsx
@@ -23,6 +23,13 @@ import InheritanceConcept from './InheritanceConcept';
 import EncapsulationConcept from './EncapsulationConcept';
 import PolymorphismConcept from './PolymorphismConcept';
 import AbstractionConcept from './AbstractionConcept';
+import StackConcept from './StackConcept';
+import QueueConcept from './QueueConcept';
+import TreeConcept from './TreeConcept';
+import AlgorithmAnalysisConcept from './AlgorithmAnalysisConcept';
+import RecursionVisualConcept from './RecursionVisualConcept';
+import SearchingConcept from './SearchingConcept';
+import SortingConcept from './SortingConcept';
 
 const navItems = [
 	{
@@ -79,6 +86,25 @@ const navItems = [
 			{ label: 'Encapsulation', value: 'encapsulation' },
 			{ label: 'Polymorphism', value: 'polymorphism' },
 			{ label: 'Abstraction', value: 'abstraction' },
+		]
+	},
+	{
+		label: 'Data Structures',
+		value: 'data-structures',
+		children: [
+			{ label: 'Stacks', value: 'stacks' },
+			{ label: 'Queues', value: 'queues' },
+			{ label: 'Trees', value: 'trees' },
+		]
+	},
+	{
+		label: 'Algorithms',
+		value: 'algorithms',
+		children: [
+			{ label: 'Algorithm Analysis & Design', value: 'algorithm-analysis' },
+			{ label: 'Recursion', value: 'recursion-viz' },
+			{ label: 'Searching', value: 'searching' },
+			{ label: 'Sorting', value: 'sorting' },
 		]
 	}
 ];
@@ -137,6 +163,20 @@ export default function PythonPage() {
                 return <PolymorphismConcept />;
             case 'abstraction':
                 return <AbstractionConcept />;
+            case 'stacks':
+                return <StackConcept />;
+            case 'queues':
+                return <QueueConcept />;
+            case 'trees':
+                return <TreeConcept />;
+            case 'algorithm-analysis':
+                return <AlgorithmAnalysisConcept />;
+            case 'recursion-viz':
+                return <RecursionVisualConcept />;
+            case 'searching':
+                return <SearchingConcept />;
+            case 'sorting':
+                return <SortingConcept />;
             default:
 				return null;
 		}
@@ -151,7 +191,7 @@ export default function PythonPage() {
 		<PageWrapper
 			pageTitle={'Python Visualizer'}
 			navItems={navItems}
-			defaultOpen={["functions", "code-organization", "oop"]}
+			defaultOpen={[]}
 			handleSelect={handleSelect}
 			activeValue={selectedConcept || undefined}
 		>

--- a/components/pageComponents/Python/PythonPage.tsx
+++ b/components/pageComponents/Python/PythonPage.tsx
@@ -17,6 +17,12 @@ import ForLoopConcept from './ForLoopConcept';
 import RecursionConcept from './RecursionConcept';
 import FunctionBasicsConcept from './FunctionBasicsConcept';
 import ModulesConcept from './ModulesConcept';
+import ClassesObjectsConcept from './ClassesObjectsConcept';
+import AttributesMethodsConcept from './AttributesMethodsConcept';
+import InheritanceConcept from './InheritanceConcept';
+import EncapsulationConcept from './EncapsulationConcept';
+import PolymorphismConcept from './PolymorphismConcept';
+import AbstractionConcept from './AbstractionConcept';
 
 const navItems = [
 	{
@@ -61,6 +67,18 @@ const navItems = [
 		value: 'code-organization',
 		children: [
 			{ label: 'Modules', value: 'modules' },
+		]
+	},
+	{
+		label: 'Object-Oriented Programming',
+		value: 'oop',
+		children: [
+			{ label: 'Classes & Objects', value: 'classes-objects' },
+			{ label: 'Attributes & Methods', value: 'attributes-methods' },
+			{ label: 'Inheritance', value: 'inheritance' },
+			{ label: 'Encapsulation', value: 'encapsulation' },
+			{ label: 'Polymorphism', value: 'polymorphism' },
+			{ label: 'Abstraction', value: 'abstraction' },
 		]
 	}
 ];
@@ -107,6 +125,18 @@ export default function PythonPage() {
                 return <FunctionBasicsConcept />;
             case 'modules':
                 return <ModulesConcept />;
+            case 'classes-objects':
+                return <ClassesObjectsConcept />;
+            case 'attributes-methods':
+                return <AttributesMethodsConcept />;
+            case 'inheritance':
+                return <InheritanceConcept />;
+            case 'encapsulation':
+                return <EncapsulationConcept />;
+            case 'polymorphism':
+                return <PolymorphismConcept />;
+            case 'abstraction':
+                return <AbstractionConcept />;
             default:
 				return null;
 		}
@@ -121,7 +151,7 @@ export default function PythonPage() {
 		<PageWrapper
 			pageTitle={'Python Visualizer'}
 			navItems={navItems}
-			defaultOpen={["functions", "code-organization"]}
+			defaultOpen={["functions", "code-organization", "oop"]}
 			handleSelect={handleSelect}
 			activeValue={selectedConcept || undefined}
 		>

--- a/components/pageComponents/Python/QueueConcept.tsx
+++ b/components/pageComponents/Python/QueueConcept.tsx
@@ -6,10 +6,9 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
@@ -30,66 +29,59 @@ export default function QueueConcept() {
     const value = input.trim() === '' ? names[Math.floor(Math.random() * names.length)] : input.trim();
     setQueue((prev) => [...prev, { id: nextId, value }]);
     setNextId((n) => n + 1);
-    setMessage(`enqueue(${value}) — joined the back of the line`);
+    setMessage(`enqueue(${value}) — added to the back of the line.`);
     setInput('');
   };
 
   const dequeue = () => {
     if (queue.length === 0) {
-      setMessage('dequeue() — the line is empty, no one to serve!');
+      setMessage('dequeue() — the queue is empty, so there is no one to serve.');
       return;
     }
     const front = queue[0];
     setQueue((prev) => prev.slice(1));
-    setMessage(`dequeue() → served ${front.value} (the person who waited longest)`);
+    setMessage(`dequeue() returned ${front.value} — the item that had waited longest.`);
   };
 
   const peek = () => {
     if (queue.length === 0) {
-      setMessage('peek() — the line is empty!');
+      setMessage('peek() — the queue is empty.');
       return;
     }
-    setMessage(`peek() → ${queue[0].value} is next to be served`);
+    setMessage(`peek() returned ${queue[0].value} — the item that will be served next.`);
   };
 
   return (
     <ConceptWrapper
       title="Queues"
-      description="A queue is a First-In, First-Out (FIFO) collection — the first thing you add is the first thing you take out."
+      description="A queue is a First-In, First-Out (FIFO) collection: the item that has waited longest is the first one removed."
     >
       <TableOfContents numbered>
-        <Section title="Picture a Line at the Store">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            A queue works exactly like a <strong>line of people</strong> waiting at a checkout. New people join at the <em>back</em>, and the person at the <em>front</em> is always served next. It&apos;s fair: whoever has been waiting longest goes first.
+            A queue works exactly like a line of people at a checkout. New arrivals join at the <em>back</em>, and the person at the <em>front</em> is always served next. It is inherently fair: whoever has waited longest is handled first.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              First In, First Out (FIFO)
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>🧍 A checkout line:</strong> first to arrive is first to be served
-              </Typography>
-              <Typography variant="body2">
-                <strong>🖨️ A printer queue:</strong> documents print in the order they were sent
-              </Typography>
-              <Typography variant="body2">
-                <strong>🎫 Customer support tickets:</strong> handled in the order they came in
-              </Typography>
+          <CalloutBox title="First In, First Out (FIFO)" type="info">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A checkout line:</strong> the first to arrive is the first to be served.</Typography>
+              <Typography variant="body2"><strong>A printer queue:</strong> documents print in the order they were submitted.</Typography>
+              <Typography variant="body2"><strong>Support tickets:</strong> requests are handled in the order they arrive.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
 
-          <Alert severity="info" sx={{ mt: 2 }}>
+          <CalloutBox title="The opposite of a stack" type="key-concepts">
             <Typography variant="body2">
-              This is the opposite of a <strong>stack</strong>. A stack removes the <em>newest</em> item first (LIFO); a queue removes the <em>oldest</em> item first (FIFO).
+              A stack removes the <em>newest</em> item first (LIFO); a queue removes the <em>oldest</em> item first (FIFO).
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
-        <Section title="Try It Yourself">
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="Interactive Queue">
           <Typography variant="body2" paragraph>
-            <strong>Enqueue</strong> adds a person to the back of the line. <strong>Dequeue</strong> serves the person at the front. Notice that things enter on one end and leave from the other.
+            <strong>Enqueue</strong> adds an item to the back of the line; <strong>Dequeue</strong> serves the item at the front. Items enter at one end and leave from the other.
           </Typography>
 
           <div className="ds-viz">
@@ -109,7 +101,7 @@ export default function QueueConcept() {
 
             <div className="queue-area">
               {queue.length === 0 ? (
-                <span className="queue-empty">The line is empty — enqueue someone!</span>
+                <span className="queue-empty">The queue is empty — enqueue an item to begin.</span>
               ) : (
                 <AnimatePresence initial={false}>
                   {queue.map((item, idx) => (
@@ -122,59 +114,56 @@ export default function QueueConcept() {
                       exit={{ opacity: 0, x: -40 }}
                       transition={{ duration: 0.25 }}
                     >
-                      {idx === 0 && <span className="queue-tag front">FRONT ↓</span>}
+                      {idx === 0 && <span className="queue-tag front">front</span>}
                       {idx === queue.length - 1 && queue.length > 1 && (
-                        <span className="queue-tag back">BACK ↓</span>
+                        <span className="queue-tag back">back</span>
                       )}
-                      <span className="queue-emoji">🧍</span>
+                      <span className="queue-avatar" />
                       {item.value}
                     </motion.div>
                   ))}
                 </AnimatePresence>
               )}
             </div>
-            <p className="ds-caption">People join on the right (back) and are served from the left (front).</p>
+            <p className="ds-caption">Items join on the right (back) and are served from the left (front).</p>
 
             {message && <p className="ds-output">{message}</p>}
           </div>
         </Section>
 
+        {/* 3 ----------------------------------------------------------------- */}
         <Section title="The Core Operations">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Typography variant="body2">
-                <strong>enqueue(item)</strong> — add an item to the back of the queue
-              </Typography>
-              <Typography variant="body2">
-                <strong>dequeue()</strong> — remove and return the front item
-              </Typography>
-              <Typography variant="body2">
-                <strong>peek()</strong> — look at the front item without removing it
-              </Typography>
-              <Typography variant="body2">
-                <strong>is_empty()</strong> — check whether anyone is still waiting
-              </Typography>
+          <CalloutBox title="Every queue supports four operations" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>enqueue(item)</strong> — add an item to the back of the queue.</Typography>
+              <Typography variant="body2"><strong>dequeue()</strong> — remove and return the front item.</Typography>
+              <Typography variant="body2"><strong>peek()</strong> — read the front item without removing it.</Typography>
+              <Typography variant="body2"><strong>is_empty()</strong> — check whether any items remain.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
         </Section>
 
-        <Section title="Where Queues Show Up">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Task scheduling:</strong> operating systems line up jobs to run in order
-              </Typography>
-              <Typography variant="body2">
-                <strong>Printing:</strong> print jobs are handled first-come, first-served
-              </Typography>
-              <Typography variant="body2">
-                <strong>Breadth-first search:</strong> exploring a graph or tree level by level uses a queue
-              </Typography>
-              <Typography variant="body2">
-                <strong>Messaging systems:</strong> messages wait in line to be processed fairly
-              </Typography>
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Where Queues Are Used">
+          <CalloutBox title="Common applications" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Task scheduling:</strong> operating systems line up jobs to run in order.</Typography>
+              <Typography variant="body2"><strong>Printing:</strong> print jobs are handled on a first-come, first-served basis.</Typography>
+              <Typography variant="body2"><strong>Breadth-first search:</strong> exploring a graph or tree level by level relies on a queue.</Typography>
+              <Typography variant="body2"><strong>Messaging systems:</strong> messages wait in line to be processed in order.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
+        </Section>
+
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Summary" type="success">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A queue is First-In, First-Out:</strong> the oldest item is removed first.</Typography>
+              <Typography variant="body2"><strong>Items enter at the back and leave from the front</strong> via enqueue and dequeue.</Typography>
+              <Typography variant="body2"><strong>Queues model fair, in-order processing</strong> such as scheduling and printing.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/QueueConcept.tsx
+++ b/components/pageComponents/Python/QueueConcept.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type Item = { id: number; value: string };
+
+export default function QueueConcept() {
+  const [queue, setQueue] = useState<Item[]>([
+    { id: 1, value: 'Ann' },
+    { id: 2, value: 'Ben' },
+    { id: 3, value: 'Cara' },
+  ]);
+  const [nextId, setNextId] = useState(4);
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const enqueue = () => {
+    const names = ['Dia', 'Eli', 'Fay', 'Gus', 'Hana', 'Ivy', 'Jon'];
+    const value = input.trim() === '' ? names[Math.floor(Math.random() * names.length)] : input.trim();
+    setQueue((prev) => [...prev, { id: nextId, value }]);
+    setNextId((n) => n + 1);
+    setMessage(`enqueue(${value}) — joined the back of the line`);
+    setInput('');
+  };
+
+  const dequeue = () => {
+    if (queue.length === 0) {
+      setMessage('dequeue() — the line is empty, no one to serve!');
+      return;
+    }
+    const front = queue[0];
+    setQueue((prev) => prev.slice(1));
+    setMessage(`dequeue() → served ${front.value} (the person who waited longest)`);
+  };
+
+  const peek = () => {
+    if (queue.length === 0) {
+      setMessage('peek() — the line is empty!');
+      return;
+    }
+    setMessage(`peek() → ${queue[0].value} is next to be served`);
+  };
+
+  return (
+    <ConceptWrapper
+      title="Queues"
+      description="A queue is a First-In, First-Out (FIFO) collection — the first thing you add is the first thing you take out."
+    >
+      <TableOfContents numbered>
+        <Section title="Picture a Line at the Store">
+          <Typography variant="body2" paragraph>
+            A queue works exactly like a <strong>line of people</strong> waiting at a checkout. New people join at the <em>back</em>, and the person at the <em>front</em> is always served next. It&apos;s fair: whoever has been waiting longest goes first.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              First In, First Out (FIFO)
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>🧍 A checkout line:</strong> first to arrive is first to be served
+              </Typography>
+              <Typography variant="body2">
+                <strong>🖨️ A printer queue:</strong> documents print in the order they were sent
+              </Typography>
+              <Typography variant="body2">
+                <strong>🎫 Customer support tickets:</strong> handled in the order they came in
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              This is the opposite of a <strong>stack</strong>. A stack removes the <em>newest</em> item first (LIFO); a queue removes the <em>oldest</em> item first (FIFO).
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Try It Yourself">
+          <Typography variant="body2" paragraph>
+            <strong>Enqueue</strong> adds a person to the back of the line. <strong>Dequeue</strong> serves the person at the front. Notice that things enter on one end and leave from the other.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="ds-controls">
+              <TextField
+                label="Name (optional)"
+                size="small"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') enqueue(); }}
+                sx={{ width: 160 }}
+              />
+              <Button variant="contained" onClick={enqueue}>Enqueue</Button>
+              <Button variant="outlined" onClick={dequeue}>Dequeue</Button>
+              <Button variant="outlined" onClick={peek}>Peek</Button>
+            </div>
+
+            <div className="queue-area">
+              {queue.length === 0 ? (
+                <span className="queue-empty">The line is empty — enqueue someone!</span>
+              ) : (
+                <AnimatePresence initial={false}>
+                  {queue.map((item, idx) => (
+                    <motion.div
+                      key={item.id}
+                      className="queue-item"
+                      layout
+                      initial={{ opacity: 0, x: 40 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -40 }}
+                      transition={{ duration: 0.25 }}
+                    >
+                      {idx === 0 && <span className="queue-tag front">FRONT ↓</span>}
+                      {idx === queue.length - 1 && queue.length > 1 && (
+                        <span className="queue-tag back">BACK ↓</span>
+                      )}
+                      <span className="queue-emoji">🧍</span>
+                      {item.value}
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              )}
+            </div>
+            <p className="ds-caption">People join on the right (back) and are served from the left (front).</p>
+
+            {message && <p className="ds-output">{message}</p>}
+          </div>
+        </Section>
+
+        <Section title="The Core Operations">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>enqueue(item)</strong> — add an item to the back of the queue
+              </Typography>
+              <Typography variant="body2">
+                <strong>dequeue()</strong> — remove and return the front item
+              </Typography>
+              <Typography variant="body2">
+                <strong>peek()</strong> — look at the front item without removing it
+              </Typography>
+              <Typography variant="body2">
+                <strong>is_empty()</strong> — check whether anyone is still waiting
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Where Queues Show Up">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Task scheduling:</strong> operating systems line up jobs to run in order
+              </Typography>
+              <Typography variant="body2">
+                <strong>Printing:</strong> print jobs are handled first-come, first-served
+              </Typography>
+              <Typography variant="body2">
+                <strong>Breadth-first search:</strong> exploring a graph or tree level by level uses a queue
+              </Typography>
+              <Typography variant="body2">
+                <strong>Messaging systems:</strong> messages wait in line to be processed fairly
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -127,6 +127,22 @@ export default function RecursionVisualConcept() {
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
+        <Section title="The Input Is What Shrinks">
+          <Typography variant="body2" paragraph>
+            The value you hand a function is its <strong>input</strong>. In <code>factorial(n)</code>, the input is <code>n</code> — give it <code>4</code> and the function works on the number 4.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            Recursion&apos;s trick is that each call runs on a <strong>smaller input</strong>: <code>factorial(4)</code> calls <code>factorial(3)</code>, which calls <code>factorial(2)</code>, and so on. &quot;A smaller copy of the problem&quot; really just means &quot;the same function on a smaller input.&quot;
+          </Typography>
+
+          <CalloutBox title="The input marches toward the base case" type="info">
+            <Typography variant="body2">
+              Every call shrinks the input one step (<code>n</code> → <code>n - 1</code>) until it reaches the base case (<code>n == 1</code>) and stops. If the input never got smaller, the recursion would never end.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 3 ----------------------------------------------------------------- */}
         <Section title="Every Recursion Needs Two Things">
           <CalloutBox title="The two rules" type="info">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
@@ -145,12 +161,12 @@ export default function RecursionVisualConcept() {
         {/* 3 ----------------------------------------------------------------- */}
         <Section title="Watch It: Down, Then Back Up">
           <Typography variant="body2" paragraph>
-            Calls stack up on the way <strong>down</strong> (each waiting on a smaller copy). Once the base case answers, the results travel <strong>back up</strong> and each call finishes. Step through <code>factorial(n)</code>:
+            Pick the <strong>input</strong> with the slider. Calls stack up on the way <strong>down</strong> (each one waiting on a smaller input). Once the base case answers, the results travel <strong>back up</strong> and each call finishes.
           </Typography>
 
           <div className="ds-viz">
             <Box sx={{ px: 1, mb: 2 }}>
-              <Typography variant="body2" gutterBottom>factorial({n})</Typography>
+              <Typography variant="body2" gutterBottom>Input: <strong>n = {n}</strong> &nbsp;&rarr;&nbsp; <code>factorial({n})</code></Typography>
               <Slider value={n} min={1} max={6} step={1} marks onChange={(_, v) => setN(v as number)} valueLabelDisplay="auto" />
             </Box>
 
@@ -195,7 +211,29 @@ export default function RecursionVisualConcept() {
           />
           <CalloutBox title="Connecting back" type="success">
             <Typography variant="body2">
-              Both rules are right there: stop at the base case, otherwise call a smaller copy. That is every recursion.
+              Both rules are right there: stop at the base case, otherwise call the function on a smaller input. That is every recursion.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="Recursion in Real Programs">
+          <Typography variant="body2" paragraph>
+            A real input is rarely a tidy number like <code>n</code>. Usually it&apos;s a <strong>nested structure</strong>, and each call handles one smaller piece of it — the exact same shrinking-input idea.
+          </Typography>
+
+          <CalloutBox title="Same pattern, real inputs" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Folders on your computer:</strong> the input is a folder; process it by recursing into each subfolder. Base case: a folder with no subfolders.</Typography>
+              <Typography variant="body2"><strong>A web page or JSON:</strong> the input is an element; process it by recursing into its child elements. Base case: an element with no children.</Typography>
+              <Typography variant="body2"><strong>Comment threads:</strong> the input is a comment; show it, then recurse into its replies. Base case: a comment with no replies.</Typography>
+              <Typography variant="body2"><strong>Trees:</strong> the input is a node; visit it, then recurse into its branches — exactly how the traversals on the <em>Trees</em> page work.</Typography>
+            </Box>
+          </CalloutBox>
+
+          <CalloutBox title="Why recursion fits these" type="success">
+            <Typography variant="body2">
+              These inputs nest to no fixed depth — a folder can hold folders that hold more folders. A loop has to ask &quot;how deep?&quot;; recursion doesn&apos;t care, because each piece is simply a smaller input handed to the same function.
             </Typography>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -25,7 +25,7 @@ function factorial(n: number): number {
 function buildSnaps(n: number): Snap[] {
   const snaps: Snap[] = [];
 
-  // Going down: factorial(n) keeps calling a smaller copy of itself
+  // Descent: factorial(n) keeps calling a smaller copy of itself
   for (let i = n; i >= 1; i--) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
@@ -35,12 +35,12 @@ function buildSnaps(n: number): Snap[] {
       frames,
       desc:
         i === 1
-          ? 'factorial(1) is the base case — it can answer immediately (1) without calling deeper. The going-down phase stops here.'
-          : `factorial(${i}) can't finish yet: it needs factorial(${i - 1}) first, so it pauses and calls a smaller copy.`,
+          ? 'factorial(1) is the base case — it returns 1 immediately without calling deeper. The descent stops here.'
+          : `factorial(${i}) cannot finish yet: it needs factorial(${i - 1}) first, so it pauses and calls a smaller copy.`,
     });
   }
 
-  // Coming back up: each paused call now gets its answer and finishes
+  // Ascent: each paused call now receives its result and finishes
   for (let i = 1; i <= n; i++) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
@@ -50,8 +50,8 @@ function buildSnaps(n: number): Snap[] {
       frames,
       desc:
         i === n
-          ? `factorial(${i}) finishes and returns ${factorial(i)} — that's the final answer! 🎉`
-          : `factorial(${i}) now returns ${factorial(i)}, handing it back to factorial(${i + 1}), which was waiting for it.`,
+          ? `factorial(${i}) finishes and returns ${factorial(i)} — the final answer.`
+          : `factorial(${i}) returns ${factorial(i)}, handing it back to factorial(${i + 1}), which was waiting for it.`,
     });
   }
 
@@ -104,91 +104,91 @@ export default function RecursionVisualConcept() {
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
   const snap = snaps[step];
-  const phase = step < n ? 'Going down ⬇️ (calling smaller copies)' : 'Coming back up ⬆️ (returning answers)';
+  const phase = step < n ? 'Descent — calling smaller copies' : 'Ascent — returning answers';
 
   return (
     <ConceptWrapper
       title="Recursion"
-      description="Recursion is when a function solves a big problem by calling itself on a smaller version of the same problem."
+      description="Recursion is a technique where a function solves a problem by calling itself on a smaller version of the same problem."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            Picture a set of <strong>Russian nesting dolls</strong>. To open the biggest doll you have to open the slightly smaller one inside it, and the one inside that, and so on — until you reach the tiniest doll that doesn&apos;t open at all. Then you close them all back up, one by one.
+            Consider a set of Russian nesting dolls. To open the largest doll you must open the slightly smaller one inside it, and the one inside that, and so on, until you reach the smallest doll that does not open at all. Then you close them back up, one at a time.
           </Typography>
           <Typography variant="body2" paragraph>
-            A recursive function works the same way: it keeps handing a smaller version of the job to <em>another copy of itself</em> until the job is small enough to answer instantly.
+            A recursive function works the same way: it hands a smaller version of the job to another copy of itself until the job is small enough to answer directly.
           </Typography>
 
           <div className="ds-viz">
             <div className="illus-label">Each call contains a smaller call inside it:</div>
             <NestingDolls />
-            <p className="ds-caption">The smallest doll (red) is the &quot;base case&quot; — the one that can answer without opening anything else.</p>
+            <p className="ds-caption">The smallest doll (red) is the base case — the one that can be answered without opening anything further.</p>
           </div>
 
-          <CalloutBox title="In plain English" type="info" icon="💡">
+          <CalloutBox title="Definition" type="info">
             <Typography variant="body2">
-              <strong>Recursion</strong> = a function that calls itself, each time on a smaller or simpler input, until it hits a case simple enough to answer directly.
+              <strong>Recursion</strong> is a function that calls itself, each time on a smaller or simpler input, until it reaches a case that can be answered directly.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="The Two Rules Every Recursion Needs">
-          <CalloutBox title="Rule 1 — the base case 🛑" type="key-concepts" icon="🛑">
+        <Section title="The Two Requirements">
+          <CalloutBox title="1. The base case" type="key-concepts">
             <Typography variant="body2">
-              The simplest version of the problem, one you can answer <strong>without</strong> calling yourself again. This is what makes the chain of calls eventually <em>stop</em>. (For our nesting dolls, it&apos;s the tiniest doll.)
+              The simplest version of the problem, one that can be answered <strong>without</strong> calling the function again. The base case is what allows the chain of calls to eventually stop. For the nesting dolls, it is the smallest doll.
             </Typography>
           </CalloutBox>
 
-          <CalloutBox title="Rule 2 — the recursive case 🔁" type="key-concepts" icon="🔁">
+          <CalloutBox title="2. The recursive case" type="key-concepts">
             <Typography variant="body2">
-              The function calls itself on a <strong>smaller</strong> input, getting one step closer to the base case each time.
+              The function calls itself on a <strong>smaller</strong> input, moving one step closer to the base case with each call.
             </Typography>
           </CalloutBox>
 
-          <CalloutBox title="Forget the base case and..." type="warning" icon="⚠️">
+          <CalloutBox title="Missing base case" type="warning">
             <Typography variant="body2">
-              ...the function calls itself <strong>forever</strong>. That&apos;s an <em>infinite recursion</em>, and the program eventually runs out of memory and crashes. Always make sure every path leads to the base case.
+              Without a reachable base case, the function calls itself indefinitely. This is <em>infinite recursion</em>; the program eventually exhausts memory and crashes. Always ensure every path leads to the base case.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Down, Then Back Up">
+        <Section title="Descent, Then Ascent">
           <Typography variant="body2" paragraph>
-            Recursion happens in two phases. First it goes <strong>down</strong>, with each call pausing and asking a smaller copy for help. Once the base case answers, the results travel <strong>back up</strong>, with each paused call finishing its math.
+            Recursion proceeds in two phases. First the calls descend, each one pausing and asking a smaller copy for help. Once the base case returns an answer, results travel back up, and each paused call completes its calculation.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">⬇️ Going down — keep asking a smaller copy:</div>
+            <div className="illus-label">Descent — each call defers to a smaller copy:</div>
             <div className="flow" style={{ marginBottom: 18 }}>
               <span className="flow-step">factorial(4)</span>
-              <span className="flow-arrow">→</span>
+              <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">factorial(3)</span>
-              <span className="flow-arrow">→</span>
+              <span className="flow-arrow">&rarr;</span>
               <span className="flow-step">factorial(2)</span>
-              <span className="flow-arrow">→</span>
+              <span className="flow-arrow">&rarr;</span>
               <span className="flow-step" style={{ background: '#fee2e2', borderColor: '#f87171', color: '#991b1b' }}>factorial(1) = 1</span>
             </div>
-            <div className="illus-label">⬆️ Coming back up — now each one can finish:</div>
+            <div className="illus-label">Ascent — each call now completes:</div>
             <div className="flow">
               <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>1</span>
-              <span className="flow-arrow">→</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>2 × 1 = 2</span>
-              <span className="flow-arrow">→</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>3 × 2 = 6</span>
-              <span className="flow-arrow">→</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>4 × 6 = 24</span>
+              <span className="flow-arrow">&rarr;</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>2 &times; 1 = 2</span>
+              <span className="flow-arrow">&rarr;</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>3 &times; 2 = 6</span>
+              <span className="flow-arrow">&rarr;</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>4 &times; 6 = 24</span>
             </div>
           </div>
         </Section>
 
         {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Watch the Call Stack">
+        <Section title="Interactive Call Stack">
           <Typography variant="body2" paragraph>
-            Every time the function calls itself, the computer stacks up a paused copy — exactly like a stack of plates. When the base case is reached, the plates come off the top one at a time as each call finishes. Step through <code>factorial(n)</code> to see it.
+            Every time the function calls itself, the computer stores a paused copy on the <strong>call stack</strong> — much like a stack of plates. When the base case is reached, the copies are removed from the top one at a time as each call completes. Step through <code>factorial(n)</code> to observe this.
           </Typography>
 
           <div className="ds-viz">
@@ -220,7 +220,7 @@ export default function RecursionVisualConcept() {
             <div className="rec-frames">
               {snap.frames.map((f, i) => (
                 <div key={i} className={`rec-frame ${kindClass[f.kind]}`}>
-                  {f.kind === 'returning' ? <span className="rec-return">↩ {f.label}</span> : f.label}
+                  {f.kind === 'returning' ? <span className="rec-return">returns {f.label}</span> : f.label}
                 </div>
               ))}
             </div>
@@ -234,17 +234,17 @@ export default function RecursionVisualConcept() {
             </div>
           </div>
 
-          <CalloutBox title="Try this" type="success" icon="🧪">
+          <CalloutBox title="Suggested experiment" type="success">
             <Typography variant="body2">
-              Set <strong>n = 6</strong> and press Play. Notice how the stack grows to its tallest at the base case, then shrinks back down as the answers come up.
+              Set <strong>n = 6</strong> and press Play. Notice that the stack reaches its maximum height at the base case, then shrinks back down as each result is returned.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 5 ----------------------------------------------------------------- */}
-        <Section title="The Code Behind It">
+        <Section title="The Code">
           <Typography variant="body2" paragraph>
-            Here&apos;s the actual function the animation runs. It&apos;s tiny — that&apos;s the appeal of recursion. Notice the two rules in the code: the <strong>base case</strong> and the <strong>recursive case</strong>.
+            Below is the function the animation runs. It is intentionally short, which is the appeal of recursion. Both requirements are visible in the code: the base case and the recursive case.
           </Typography>
           <CodeSnippet
             language="python"
@@ -262,24 +262,24 @@ export default function RecursionVisualConcept() {
         {/* 6 ----------------------------------------------------------------- */}
         <Section title="Recursion vs. Loops">
           <Typography variant="body2" paragraph>
-            A loop and recursion can solve the same problems — they&apos;re equally powerful. The question is which one makes your code <em>clearer</em>.
+            A loop and recursion can solve the same problems; they are equally powerful. The question is which one expresses a given problem more clearly.
           </Typography>
 
-          <CalloutBox title="Which should I reach for?" type="key-concepts" icon="🤔">
+          <CalloutBox title="Which to choose" type="key-concepts">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Use recursion</strong> when a problem naturally breaks into smaller copies of itself — trees, nested folders, or divide-and-conquer algorithms.</Typography>
-              <Typography variant="body2"><strong>Use a loop</strong> when you&apos;re simply repeating a step a set number of times — it usually uses less memory and is easier to follow.</Typography>
+              <Typography variant="body2"><strong>Prefer recursion</strong> when a problem naturally breaks into smaller copies of itself — trees, nested folders, or divide-and-conquer algorithms.</Typography>
+              <Typography variant="body2"><strong>Prefer a loop</strong> when simply repeating a step a fixed number of times — it usually uses less memory and is easier to trace.</Typography>
             </Box>
           </CalloutBox>
         </Section>
 
         {/* 7 ----------------------------------------------------------------- */}
         <Section title="Key Takeaways">
-          <CalloutBox title="Remember these" type="success" icon="✅">
+          <CalloutBox title="Summary" type="success">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
               <Typography variant="body2"><strong>Recursion</strong> is a function calling itself on a smaller version of the problem.</Typography>
-              <Typography variant="body2"><strong>Every recursion needs a base case</strong> (to stop) and a recursive case (to shrink the problem).</Typography>
-              <Typography variant="body2"><strong>It runs in two phases:</strong> calls pile up going down, then resolve coming back up.</Typography>
+              <Typography variant="body2"><strong>Every recursion needs a base case</strong> to stop and a recursive case to shrink the problem.</Typography>
+              <Typography variant="body2"><strong>It runs in two phases:</strong> calls accumulate during the descent, then resolve during the ascent.</Typography>
             </Box>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -217,23 +217,23 @@ export default function RecursionVisualConcept() {
         </Section>
 
         {/* 6 ----------------------------------------------------------------- */}
-        <Section title="Recursion in Real Programs">
+        <Section title="When You'd Actually Use This">
           <Typography variant="body2" paragraph>
-            A real input is rarely a tidy number like <code>n</code>. Usually it&apos;s a <strong>nested structure</strong>, and each call handles one smaller piece of it — the exact same shrinking-input idea.
+            You reach for recursion when the thing you&apos;re working with <strong>contains smaller versions of itself</strong>. The input isn&apos;t a number like <code>n</code> — it&apos;s a nested structure, and each call handles one smaller piece.
           </Typography>
 
-          <CalloutBox title="Same pattern, real inputs" type="key-concepts">
+          <CalloutBox title="Real tasks that call for recursion" type="key-concepts">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Folders on your computer:</strong> the input is a folder; process it by recursing into each subfolder. Base case: a folder with no subfolders.</Typography>
-              <Typography variant="body2"><strong>A web page or JSON:</strong> the input is an element; process it by recursing into its child elements. Base case: an element with no children.</Typography>
-              <Typography variant="body2"><strong>Comment threads:</strong> the input is a comment; show it, then recurse into its replies. Base case: a comment with no replies.</Typography>
-              <Typography variant="body2"><strong>Trees:</strong> the input is a node; visit it, then recurse into its branches — exactly how the traversals on the <em>Trees</em> page work.</Typography>
+              <Typography variant="body2"><strong>&quot;How big is this folder?&quot;</strong> Add up every file inside it — and inside its subfolders, and theirs. Each subfolder is a smaller folder handed to the same function.</Typography>
+              <Typography variant="body2"><strong>Showing a comment thread:</strong> display a comment, then its replies, then the replies to those replies (a forum or social feed).</Typography>
+              <Typography variant="body2"><strong>A category menu:</strong> a shopping site&apos;s navigation where categories open into sub-categories that open into more.</Typography>
+              <Typography variant="body2"><strong>Drawing a family tree or org chart:</strong> each person branches into the people below them.</Typography>
             </Box>
           </CalloutBox>
 
-          <CalloutBox title="Why recursion fits these" type="success">
+          <CalloutBox title="Why a loop won't cut it" type="success">
             <Typography variant="body2">
-              These inputs nest to no fixed depth — a folder can hold folders that hold more folders. A loop has to ask &quot;how deep?&quot;; recursion doesn&apos;t care, because each piece is simply a smaller input handed to the same function.
+              These nest to no fixed depth — a folder can hold folders that hold more folders forever. A plain loop has to know &quot;how deep?&quot; in advance; recursion doesn&apos;t, because each piece is just a smaller input handed back to the same function.
             </Typography>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -5,10 +5,9 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Slider from '@mui/material/Slider';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import CodeSnippet from '../../common/CodeSnippet';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
@@ -26,39 +25,33 @@ function factorial(n: number): number {
 function buildSnaps(n: number): Snap[] {
   const snaps: Snap[] = [];
 
-  // Descent: factorial(n) calls down to the base case
+  // Going down: factorial(n) keeps calling a smaller copy of itself
   for (let i = n; i >= 1; i--) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
-      frames.push({
-        label: `factorial(${j})`,
-        kind: j === i ? (i === 1 ? 'base' : 'calling') : 'waiting',
-      });
+      frames.push({ label: `factorial(${j})`, kind: j === i ? (i === 1 ? 'base' : 'calling') : 'waiting' });
     }
     snaps.push({
       frames,
       desc:
         i === 1
-          ? 'factorial(1) is the base case — it can return 1 immediately without calling deeper.'
-          : `factorial(${i}) can't finish yet: it needs factorial(${i - 1}), so it pauses and calls deeper.`,
+          ? 'factorial(1) is the base case — it can answer immediately (1) without calling deeper. The going-down phase stops here.'
+          : `factorial(${i}) can't finish yet: it needs factorial(${i - 1}) first, so it pauses and calls a smaller copy.`,
     });
   }
 
-  // Ascent: each frame returns its value and pops off the stack
+  // Coming back up: each paused call now gets its answer and finishes
   for (let i = 1; i <= n; i++) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
-      frames.push({
-        label: j === i ? `factorial(${j}) = ${factorial(j)}` : `factorial(${j})`,
-        kind: j === i ? 'returning' : 'waiting',
-      });
+      frames.push({ label: j === i ? `factorial(${j}) = ${factorial(j)}` : `factorial(${j})`, kind: j === i ? 'returning' : 'waiting' });
     }
     snaps.push({
       frames,
       desc:
         i === n
-          ? `factorial(${i}) returns ${factorial(i)} — that's the final answer! 🎉`
-          : `factorial(${i}) returns ${factorial(i)}, handing it back to factorial(${i + 1}).`,
+          ? `factorial(${i}) finishes and returns ${factorial(i)} — that's the final answer! 🎉`
+          : `factorial(${i}) now returns ${factorial(i)}, handing it back to factorial(${i + 1}), which was waiting for it.`,
     });
   }
 
@@ -72,6 +65,26 @@ const kindClass: Record<Kind, string> = {
   returning: 'returning active',
 };
 
+// Nesting-dolls illustration: each ring is a smaller call inside a bigger one
+function NestingDolls() {
+  const rings = [
+    { w: 300, h: 190, x: 10, y: 15, fill: '#dbeafe', stroke: '#60a5fa', label: 'factorial(4)', ly: 34 },
+    { w: 224, h: 140, x: 48, y: 40, fill: '#bfdbfe', stroke: '#3b82f6', label: 'factorial(3)', ly: 59 },
+    { w: 148, h: 90, x: 86, y: 65, fill: '#c7d2fe', stroke: '#6366f1', label: 'factorial(2)', ly: 84 },
+    { w: 92, h: 48, x: 114, y: 86, fill: '#fee2e2', stroke: '#f87171', label: 'factorial(1) = 1', ly: 114 },
+  ];
+  return (
+    <svg viewBox="0 0 320 220" style={{ width: '100%', maxWidth: 360, display: 'block', margin: '0 auto' }}>
+      {rings.map((r, i) => (
+        <g key={i}>
+          <rect x={r.x} y={r.y} width={r.w} height={r.h} rx={14} fill={r.fill} stroke={r.stroke} strokeWidth={2} />
+          <text x={160} y={r.ly} textAnchor="middle" fontSize={13} fontWeight={700} fill="#1e293b">{r.label}</text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
 export default function RecursionVisualConcept() {
   const [n, setN] = useState(4);
   const snaps = useMemo(() => buildSnaps(n), [n]);
@@ -79,13 +92,8 @@ export default function RecursionVisualConcept() {
   const [playing, setPlaying] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset to start whenever n changes
-  useEffect(() => {
-    setStep(0);
-    setPlaying(false);
-  }, [n]);
+  useEffect(() => { setStep(0); setPlaying(false); }, [n]);
 
-  // Auto-play
   useEffect(() => {
     if (!playing) return;
     if (step >= snaps.length - 1) { setPlaying(false); return; }
@@ -96,43 +104,91 @@ export default function RecursionVisualConcept() {
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
   const snap = snaps[step];
-  const phase = step < n ? 'Calling deeper ⬇️' : 'Returning back up ⬆️';
+  const phase = step < n ? 'Going down ⬇️ (calling smaller copies)' : 'Coming back up ⬆️ (returning answers)';
 
   return (
     <ConceptWrapper
       title="Recursion"
-      description="Recursion is when a function solves a problem by calling itself on a smaller version of that problem."
+      description="Recursion is when a function solves a big problem by calling itself on a smaller version of the same problem."
     >
       <TableOfContents numbered>
-        <Section title="Think of Nesting Dolls">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            A recursive function is like a set of <strong>Russian nesting dolls</strong>. To open the biggest doll you open the next one inside, and the next, until you reach the tiniest doll that doesn&apos;t open — the <strong>base case</strong>. Then you close them back up one by one.
+            Picture a set of <strong>Russian nesting dolls</strong>. To open the biggest doll you have to open the slightly smaller one inside it, and the one inside that, and so on — until you reach the tiniest doll that doesn&apos;t open at all. Then you close them all back up, one by one.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            A recursive function works the same way: it keeps handing a smaller version of the job to <em>another copy of itself</em> until the job is small enough to answer instantly.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              Every Recursion Needs Two Things
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>🛑 A base case:</strong> the simplest version that can be answered directly, so the calls stop
-              </Typography>
-              <Typography variant="body2">
-                <strong>🔁 A recursive case:</strong> the function calls itself on a smaller input, moving toward the base case
-              </Typography>
-            </Box>
-          </ConceptInfoCard>
+          <div className="ds-viz">
+            <div className="illus-label">Each call contains a smaller call inside it:</div>
+            <NestingDolls />
+            <p className="ds-caption">The smallest doll (red) is the &quot;base case&quot; — the one that can answer without opening anything else.</p>
+          </div>
 
-          <Alert severity="warning" sx={{ mt: 2 }}>
+          <CalloutBox title="In plain English" type="info" icon="💡">
             <Typography variant="body2">
-              Forget the base case and the function calls itself forever — that&apos;s an <strong>infinite recursion</strong>, and the program crashes when the call stack runs out of room.
+              <strong>Recursion</strong> = a function that calls itself, each time on a smaller or simpler input, until it hits a case simple enough to answer directly.
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="The Two Rules Every Recursion Needs">
+          <CalloutBox title="Rule 1 — the base case 🛑" type="key-concepts" icon="🛑">
+            <Typography variant="body2">
+              The simplest version of the problem, one you can answer <strong>without</strong> calling yourself again. This is what makes the chain of calls eventually <em>stop</em>. (For our nesting dolls, it&apos;s the tiniest doll.)
+            </Typography>
+          </CalloutBox>
+
+          <CalloutBox title="Rule 2 — the recursive case 🔁" type="key-concepts" icon="🔁">
+            <Typography variant="body2">
+              The function calls itself on a <strong>smaller</strong> input, getting one step closer to the base case each time.
+            </Typography>
+          </CalloutBox>
+
+          <CalloutBox title="Forget the base case and..." type="warning" icon="⚠️">
+            <Typography variant="body2">
+              ...the function calls itself <strong>forever</strong>. That&apos;s an <em>infinite recursion</em>, and the program eventually runs out of memory and crashes. Always make sure every path leads to the base case.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 3 ----------------------------------------------------------------- */}
+        <Section title="Down, Then Back Up">
+          <Typography variant="body2" paragraph>
+            Recursion happens in two phases. First it goes <strong>down</strong>, with each call pausing and asking a smaller copy for help. Once the base case answers, the results travel <strong>back up</strong>, with each paused call finishing its math.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="illus-label">⬇️ Going down — keep asking a smaller copy:</div>
+            <div className="flow" style={{ marginBottom: 18 }}>
+              <span className="flow-step">factorial(4)</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step">factorial(3)</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step">factorial(2)</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step" style={{ background: '#fee2e2', borderColor: '#f87171', color: '#991b1b' }}>factorial(1) = 1</span>
+            </div>
+            <div className="illus-label">⬆️ Coming back up — now each one can finish:</div>
+            <div className="flow">
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>1</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>2 × 1 = 2</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>3 × 2 = 6</span>
+              <span className="flow-arrow">→</span>
+              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>4 × 6 = 24</span>
+            </div>
+          </div>
+        </Section>
+
+        {/* 4 ----------------------------------------------------------------- */}
         <Section title="Watch the Call Stack">
           <Typography variant="body2" paragraph>
-            Each time the function calls itself, the computer stacks up a paused copy (a <strong>frame</strong>) — exactly like a stack of plates. Once the base case is hit, the frames resolve from the top down. Step through <code>factorial(n)</code> below to see it happen.
+            Every time the function calls itself, the computer stacks up a paused copy — exactly like a stack of plates. When the base case is reached, the plates come off the top one at a time as each call finishes. Step through <code>factorial(n)</code> to see it.
           </Typography>
 
           <div className="ds-viz">
@@ -169,9 +225,7 @@ export default function RecursionVisualConcept() {
               ))}
             </div>
 
-            <p className="ds-output">
-              <strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}
-            </p>
+            <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
 
             <div className="ds-legend">
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Calling deeper</span>
@@ -179,39 +233,55 @@ export default function RecursionVisualConcept() {
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#dcfce7', borderColor: '#4ade80' }} /> Returning a value</span>
             </div>
           </div>
+
+          <CalloutBox title="Try this" type="success" icon="🧪">
+            <Typography variant="body2">
+              Set <strong>n = 6</strong> and press Play. Notice how the stack grows to its tallest at the base case, then shrinks back down as the answers come up.
+            </Typography>
+          </CalloutBox>
         </Section>
 
+        {/* 5 ----------------------------------------------------------------- */}
         <Section title="The Code Behind It">
           <Typography variant="body2" paragraph>
-            Here&apos;s the function the animation is running. Notice how small it is — recursion lets you express &quot;do this, then the rest&quot; very compactly.
+            Here&apos;s the actual function the animation runs. It&apos;s tiny — that&apos;s the appeal of recursion. Notice the two rules in the code: the <strong>base case</strong> and the <strong>recursive case</strong>.
           </Typography>
           <CodeSnippet
             language="python"
             lines={[
               { code: 'def factorial(n):' },
-              { code: '    if n == 1:          # base case' },
+              { code: '    if n == 1:                    # base case: stop here' },
               { code: '        return 1' },
-              { code: '    return n * factorial(n - 1)   # recursive case' },
+              { code: '    return n * factorial(n - 1)   # recursive case: smaller copy' },
               { code: '' },
               { code: 'print(factorial(4))   # 24' }
             ]}
           />
         </Section>
 
+        {/* 6 ----------------------------------------------------------------- */}
         <Section title="Recursion vs. Loops">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Anything recursive can be written with a loop</strong>, and vice versa — they&apos;re equally powerful.
-              </Typography>
-              <Typography variant="body2">
-                <strong>Reach for recursion</strong> when a problem naturally breaks into smaller copies of itself: trees, nested folders, or divide-and-conquer algorithms.
-              </Typography>
-              <Typography variant="body2">
-                <strong>Reach for a loop</strong> when you&apos;re simply repeating a step a fixed number of times — it usually uses less memory.
-              </Typography>
+          <Typography variant="body2" paragraph>
+            A loop and recursion can solve the same problems — they&apos;re equally powerful. The question is which one makes your code <em>clearer</em>.
+          </Typography>
+
+          <CalloutBox title="Which should I reach for?" type="key-concepts" icon="🤔">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Use recursion</strong> when a problem naturally breaks into smaller copies of itself — trees, nested folders, or divide-and-conquer algorithms.</Typography>
+              <Typography variant="body2"><strong>Use a loop</strong> when you&apos;re simply repeating a step a set number of times — it usually uses less memory and is easier to follow.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
+        </Section>
+
+        {/* 7 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Remember these" type="success" icon="✅">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Recursion</strong> is a function calling itself on a smaller version of the problem.</Typography>
+              <Typography variant="body2"><strong>Every recursion needs a base case</strong> (to stop) and a recursive case (to shrink the problem).</Typography>
+              <Typography variant="body2"><strong>It runs in two phases:</strong> calls pile up going down, then resolve coming back up.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Slider from '@mui/material/Slider';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CodeSnippet from '../../common/CodeSnippet';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type Kind = 'waiting' | 'calling' | 'base' | 'returning';
+type Frame = { label: string; kind: Kind };
+type Snap = { frames: Frame[]; desc: string };
+
+function factorial(n: number): number {
+  let r = 1;
+  for (let i = 2; i <= n; i++) r *= i;
+  return r;
+}
+
+function buildSnaps(n: number): Snap[] {
+  const snaps: Snap[] = [];
+
+  // Descent: factorial(n) calls down to the base case
+  for (let i = n; i >= 1; i--) {
+    const frames: Frame[] = [];
+    for (let j = i; j <= n; j++) {
+      frames.push({
+        label: `factorial(${j})`,
+        kind: j === i ? (i === 1 ? 'base' : 'calling') : 'waiting',
+      });
+    }
+    snaps.push({
+      frames,
+      desc:
+        i === 1
+          ? 'factorial(1) is the base case — it can return 1 immediately without calling deeper.'
+          : `factorial(${i}) can't finish yet: it needs factorial(${i - 1}), so it pauses and calls deeper.`,
+    });
+  }
+
+  // Ascent: each frame returns its value and pops off the stack
+  for (let i = 1; i <= n; i++) {
+    const frames: Frame[] = [];
+    for (let j = i; j <= n; j++) {
+      frames.push({
+        label: j === i ? `factorial(${j}) = ${factorial(j)}` : `factorial(${j})`,
+        kind: j === i ? 'returning' : 'waiting',
+      });
+    }
+    snaps.push({
+      frames,
+      desc:
+        i === n
+          ? `factorial(${i}) returns ${factorial(i)} — that's the final answer! 🎉`
+          : `factorial(${i}) returns ${factorial(i)}, handing it back to factorial(${i + 1}).`,
+    });
+  }
+
+  return snaps;
+}
+
+const kindClass: Record<Kind, string> = {
+  waiting: '',
+  calling: 'calling active',
+  base: 'base active',
+  returning: 'returning active',
+};
+
+export default function RecursionVisualConcept() {
+  const [n, setN] = useState(4);
+  const snaps = useMemo(() => buildSnaps(n), [n]);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset to start whenever n changes
+  useEffect(() => {
+    setStep(0);
+    setPlaying(false);
+  }, [n]);
+
+  // Auto-play
+  useEffect(() => {
+    if (!playing) return;
+    if (step >= snaps.length - 1) { setPlaying(false); return; }
+    timer.current = setTimeout(() => setStep((s) => s + 1), 1100);
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, [playing, step, snaps.length]);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  const snap = snaps[step];
+  const phase = step < n ? 'Calling deeper ⬇️' : 'Returning back up ⬆️';
+
+  return (
+    <ConceptWrapper
+      title="Recursion"
+      description="Recursion is when a function solves a problem by calling itself on a smaller version of that problem."
+    >
+      <TableOfContents numbered>
+        <Section title="Think of Nesting Dolls">
+          <Typography variant="body2" paragraph>
+            A recursive function is like a set of <strong>Russian nesting dolls</strong>. To open the biggest doll you open the next one inside, and the next, until you reach the tiniest doll that doesn&apos;t open — the <strong>base case</strong>. Then you close them back up one by one.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Every Recursion Needs Two Things
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>🛑 A base case:</strong> the simplest version that can be answered directly, so the calls stop
+              </Typography>
+              <Typography variant="body2">
+                <strong>🔁 A recursive case:</strong> the function calls itself on a smaller input, moving toward the base case
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Forget the base case and the function calls itself forever — that&apos;s an <strong>infinite recursion</strong>, and the program crashes when the call stack runs out of room.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Watch the Call Stack">
+          <Typography variant="body2" paragraph>
+            Each time the function calls itself, the computer stacks up a paused copy (a <strong>frame</strong>) — exactly like a stack of plates. Once the base case is hit, the frames resolve from the top down. Step through <code>factorial(n)</code> below to see it happen.
+          </Typography>
+
+          <div className="ds-viz">
+            <Box sx={{ px: 1, mb: 2 }}>
+              <Typography variant="body2" gutterBottom>
+                Compute <strong>factorial({n})</strong>
+              </Typography>
+              <Slider value={n} min={1} max={6} step={1} marks onChange={(_, v) => setN(v as number)} valueLabelDisplay="auto" />
+            </Box>
+
+            <div className="ds-controls">
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
+                Previous
+              </Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
+                Next
+              </Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
+                {playing ? 'Pause' : 'Play'}
+              </Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
+                Reset
+              </Button>
+              <Typography variant="body2" sx={{ ml: 'auto', fontWeight: 600, color: '#475569' }}>
+                {phase}
+              </Typography>
+            </div>
+
+            <div className="rec-frames">
+              {snap.frames.map((f, i) => (
+                <div key={i} className={`rec-frame ${kindClass[f.kind]}`}>
+                  {f.kind === 'returning' ? <span className="rec-return">↩ {f.label}</span> : f.label}
+                </div>
+              ))}
+            </div>
+
+            <p className="ds-output">
+              <strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}
+            </p>
+
+            <div className="ds-legend">
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Calling deeper</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fee2e2', borderColor: '#f87171' }} /> Base case</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#dcfce7', borderColor: '#4ade80' }} /> Returning a value</span>
+            </div>
+          </div>
+        </Section>
+
+        <Section title="The Code Behind It">
+          <Typography variant="body2" paragraph>
+            Here&apos;s the function the animation is running. Notice how small it is — recursion lets you express &quot;do this, then the rest&quot; very compactly.
+          </Typography>
+          <CodeSnippet
+            language="python"
+            lines={[
+              { code: 'def factorial(n):' },
+              { code: '    if n == 1:          # base case' },
+              { code: '        return 1' },
+              { code: '    return n * factorial(n - 1)   # recursive case' },
+              { code: '' },
+              { code: 'print(factorial(4))   # 24' }
+            ]}
+          />
+        </Section>
+
+        <Section title="Recursion vs. Loops">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Anything recursive can be written with a loop</strong>, and vice versa — they&apos;re equally powerful.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Reach for recursion</strong> when a problem naturally breaks into smaller copies of itself: trees, nested folders, or divide-and-conquer algorithms.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Reach for a loop</strong> when you&apos;re simply repeating a step a fixed number of times — it usually uses less memory.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/RecursionVisualConcept.tsx
+++ b/components/pageComponents/Python/RecursionVisualConcept.tsx
@@ -25,7 +25,7 @@ function factorial(n: number): number {
 function buildSnaps(n: number): Snap[] {
   const snaps: Snap[] = [];
 
-  // Descent: factorial(n) keeps calling a smaller copy of itself
+  // Descent: each call asks a smaller copy for help
   for (let i = n; i >= 1; i--) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
@@ -35,12 +35,12 @@ function buildSnaps(n: number): Snap[] {
       frames,
       desc:
         i === 1
-          ? 'factorial(1) is the base case — it returns 1 immediately without calling deeper. The descent stops here.'
-          : `factorial(${i}) cannot finish yet: it needs factorial(${i - 1}) first, so it pauses and calls a smaller copy.`,
+          ? 'factorial(1) is the base case — it answers 1 right away. The descent stops here.'
+          : `factorial(${i}) needs factorial(${i - 1}) first, so it pauses and calls a smaller copy.`,
     });
   }
 
-  // Ascent: each paused call now receives its result and finishes
+  // Ascent: each paused call now finishes
   for (let i = 1; i <= n; i++) {
     const frames: Frame[] = [];
     for (let j = i; j <= n; j++) {
@@ -50,8 +50,8 @@ function buildSnaps(n: number): Snap[] {
       frames,
       desc:
         i === n
-          ? `factorial(${i}) finishes and returns ${factorial(i)} — the final answer.`
-          : `factorial(${i}) returns ${factorial(i)}, handing it back to factorial(${i + 1}), which was waiting for it.`,
+          ? `factorial(${i}) returns ${factorial(i)} — the final answer.`
+          : `factorial(${i}) returns ${factorial(i)} back to factorial(${i + 1}).`,
     });
   }
 
@@ -65,7 +65,7 @@ const kindClass: Record<Kind, string> = {
   returning: 'returning active',
 };
 
-// Nesting-dolls illustration: each ring is a smaller call inside a bigger one
+// Nesting-dolls illustration: each call sits inside a bigger one
 function NestingDolls() {
   const rings = [
     { w: 300, h: 190, x: 10, y: 15, fill: '#dbeafe', stroke: '#60a5fa', label: 'factorial(4)', ly: 34 },
@@ -104,117 +104,62 @@ export default function RecursionVisualConcept() {
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
   const snap = snaps[step];
-  const phase = step < n ? 'Descent — calling smaller copies' : 'Ascent — returning answers';
+  const phase = step < n ? 'Going down (calling smaller copies)' : 'Coming back up (returning answers)';
 
   return (
     <ConceptWrapper
       title="Recursion"
-      description="Recursion is a technique where a function solves a problem by calling itself on a smaller version of the same problem."
+      description="A function that solves a problem by calling itself."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
-          <Typography variant="body2" paragraph>
-            Consider a set of Russian nesting dolls. To open the largest doll you must open the slightly smaller one inside it, and the one inside that, and so on, until you reach the smallest doll that does not open at all. Then you close them back up, one at a time.
-          </Typography>
-          <Typography variant="body2" paragraph>
-            A recursive function works the same way: it hands a smaller version of the job to another copy of itself until the job is small enough to answer directly.
-          </Typography>
-
-          <div className="ds-viz">
-            <div className="illus-label">Each call contains a smaller call inside it:</div>
-            <NestingDolls />
-            <p className="ds-caption">The smallest doll (red) is the base case — the one that can be answered without opening anything further.</p>
-          </div>
-
-          <CalloutBox title="Definition" type="info">
+          <CalloutBox title="Solve a smaller copy" type="key-concepts">
             <Typography variant="body2">
-              <strong>Recursion</strong> is a function that calls itself, each time on a smaller or simpler input, until it reaches a case that can be answered directly.
+              A recursive function solves a big problem by handing a <strong>smaller copy of the same problem</strong> to itself — over and over, until the copy is tiny enough to answer instantly.
             </Typography>
           </CalloutBox>
+
+          <div className="ds-viz" style={{ marginTop: 16 }}>
+            <NestingDolls />
+            <p className="ds-caption">Like nesting dolls: open each to find a smaller one, until the tiniest (the base case) that doesn&apos;t open.</p>
+          </div>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="The Two Requirements">
-          <CalloutBox title="1. The base case" type="key-concepts">
-            <Typography variant="body2">
-              The simplest version of the problem, one that can be answered <strong>without</strong> calling the function again. The base case is what allows the chain of calls to eventually stop. For the nesting dolls, it is the smallest doll.
-            </Typography>
+        <Section title="Every Recursion Needs Two Things">
+          <CalloutBox title="The two rules" type="info">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Base case:</strong> the smallest version, answered directly — this is what makes the calls stop.</Typography>
+              <Typography variant="body2"><strong>Recursive case:</strong> call yourself on a smaller input, moving toward the base case.</Typography>
+            </Box>
           </CalloutBox>
 
-          <CalloutBox title="2. The recursive case" type="key-concepts">
+          <CalloutBox title="Forget the base case" type="warning">
             <Typography variant="body2">
-              The function calls itself on a <strong>smaller</strong> input, moving one step closer to the base case with each call.
-            </Typography>
-          </CalloutBox>
-
-          <CalloutBox title="Missing base case" type="warning">
-            <Typography variant="body2">
-              Without a reachable base case, the function calls itself indefinitely. This is <em>infinite recursion</em>; the program eventually exhausts memory and crashes. Always ensure every path leads to the base case.
+              ...and the function calls itself forever, then crashes. Every path must reach the base case.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Descent, Then Ascent">
+        <Section title="Watch It: Down, Then Back Up">
           <Typography variant="body2" paragraph>
-            Recursion proceeds in two phases. First the calls descend, each one pausing and asking a smaller copy for help. Once the base case returns an answer, results travel back up, and each paused call completes its calculation.
-          </Typography>
-
-          <div className="ds-viz">
-            <div className="illus-label">Descent — each call defers to a smaller copy:</div>
-            <div className="flow" style={{ marginBottom: 18 }}>
-              <span className="flow-step">factorial(4)</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step">factorial(3)</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step">factorial(2)</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step" style={{ background: '#fee2e2', borderColor: '#f87171', color: '#991b1b' }}>factorial(1) = 1</span>
-            </div>
-            <div className="illus-label">Ascent — each call now completes:</div>
-            <div className="flow">
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>1</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>2 &times; 1 = 2</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>3 &times; 2 = 6</span>
-              <span className="flow-arrow">&rarr;</span>
-              <span className="flow-step" style={{ background: '#dcfce7', borderColor: '#4ade80', color: '#166534' }}>4 &times; 6 = 24</span>
-            </div>
-          </div>
-        </Section>
-
-        {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Interactive Call Stack">
-          <Typography variant="body2" paragraph>
-            Every time the function calls itself, the computer stores a paused copy on the <strong>call stack</strong> — much like a stack of plates. When the base case is reached, the copies are removed from the top one at a time as each call completes. Step through <code>factorial(n)</code> to observe this.
+            Calls stack up on the way <strong>down</strong> (each waiting on a smaller copy). Once the base case answers, the results travel <strong>back up</strong> and each call finishes. Step through <code>factorial(n)</code>:
           </Typography>
 
           <div className="ds-viz">
             <Box sx={{ px: 1, mb: 2 }}>
-              <Typography variant="body2" gutterBottom>
-                Compute <strong>factorial({n})</strong>
-              </Typography>
+              <Typography variant="body2" gutterBottom>factorial({n})</Typography>
               <Slider value={n} min={1} max={6} step={1} marks onChange={(_, v) => setN(v as number)} valueLabelDisplay="auto" />
             </Box>
 
             <div className="ds-controls">
-              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
-                Previous
-              </Button>
-              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
-                Next
-              </Button>
-              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
-                {playing ? 'Pause' : 'Play'}
-              </Button>
-              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
-                Reset
-              </Button>
-              <Typography variant="body2" sx={{ ml: 'auto', fontWeight: 600, color: '#475569' }}>
-                {phase}
-              </Typography>
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>Previous</Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>Next</Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>{playing ? 'Pause' : 'Play'}</Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>Reset</Button>
+              <Typography variant="body2" sx={{ ml: 'auto', fontWeight: 600, color: '#475569' }}>{phase}</Typography>
             </div>
 
             <div className="rec-frames">
@@ -230,57 +175,28 @@ export default function RecursionVisualConcept() {
             <div className="ds-legend">
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Calling deeper</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fee2e2', borderColor: '#f87171' }} /> Base case</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#dcfce7', borderColor: '#4ade80' }} /> Returning a value</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#dcfce7', borderColor: '#4ade80' }} /> Returning</span>
             </div>
           </div>
-
-          <CalloutBox title="Suggested experiment" type="success">
-            <Typography variant="body2">
-              Set <strong>n = 6</strong> and press Play. Notice that the stack reaches its maximum height at the base case, then shrinks back down as each result is returned.
-            </Typography>
-          </CalloutBox>
         </Section>
 
-        {/* 5 ----------------------------------------------------------------- */}
+        {/* 4 ----------------------------------------------------------------- */}
         <Section title="The Code">
-          <Typography variant="body2" paragraph>
-            Below is the function the animation runs. It is intentionally short, which is the appeal of recursion. Both requirements are visible in the code: the base case and the recursive case.
-          </Typography>
           <CodeSnippet
             language="python"
             lines={[
               { code: 'def factorial(n):' },
-              { code: '    if n == 1:                    # base case: stop here' },
+              { code: '    if n == 1:                    # base case' },
               { code: '        return 1' },
-              { code: '    return n * factorial(n - 1)   # recursive case: smaller copy' },
+              { code: '    return n * factorial(n - 1)   # smaller copy' },
               { code: '' },
               { code: 'print(factorial(4))   # 24' }
             ]}
           />
-        </Section>
-
-        {/* 6 ----------------------------------------------------------------- */}
-        <Section title="Recursion vs. Loops">
-          <Typography variant="body2" paragraph>
-            A loop and recursion can solve the same problems; they are equally powerful. The question is which one expresses a given problem more clearly.
-          </Typography>
-
-          <CalloutBox title="Which to choose" type="key-concepts">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Prefer recursion</strong> when a problem naturally breaks into smaller copies of itself — trees, nested folders, or divide-and-conquer algorithms.</Typography>
-              <Typography variant="body2"><strong>Prefer a loop</strong> when simply repeating a step a fixed number of times — it usually uses less memory and is easier to trace.</Typography>
-            </Box>
-          </CalloutBox>
-        </Section>
-
-        {/* 7 ----------------------------------------------------------------- */}
-        <Section title="Key Takeaways">
-          <CalloutBox title="Summary" type="success">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Recursion</strong> is a function calling itself on a smaller version of the problem.</Typography>
-              <Typography variant="body2"><strong>Every recursion needs a base case</strong> to stop and a recursive case to shrink the problem.</Typography>
-              <Typography variant="body2"><strong>It runs in two phases:</strong> calls accumulate during the descent, then resolve during the ascent.</Typography>
-            </Box>
+          <CalloutBox title="Connecting back" type="success">
+            <Typography variant="body2">
+              Both rules are right there: stop at the base case, otherwise call a smaller copy. That is every recursion.
+            </Typography>
           </CalloutBox>
         </Section>
       </TableOfContents>

--- a/components/pageComponents/Python/SearchingConcept.tsx
+++ b/components/pageComponents/Python/SearchingConcept.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+const DATA = [2, 5, 8, 12, 16, 23, 38, 45, 56, 72, 91];
+type CellState = '' | 'range' | 'active' | 'eliminated' | 'found';
+type Snap = { states: CellState[]; desc: string };
+
+function linearSnaps(arr: number[], target: number): Snap[] {
+  const snaps: Snap[] = [];
+  for (let i = 0; i < arr.length; i++) {
+    const states: CellState[] = arr.map((_, idx) => (idx < i ? 'eliminated' : ''));
+    states[i] = 'active';
+    snaps.push({ states, desc: `Check index ${i}: is ${arr[i]} the value we want (${target})?` });
+    if (arr[i] === target) {
+      const found: CellState[] = arr.map((_, idx) => (idx < i ? 'eliminated' : ''));
+      found[i] = 'found';
+      snaps.push({ states: found, desc: `Found ${target} at index ${i}! It took ${i + 1} checks. ✅` });
+      return snaps;
+    }
+  }
+  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Checked every item — ${target} is not in the list. ❌` });
+  return snaps;
+}
+
+function binarySnaps(arr: number[], target: number): Snap[] {
+  const snaps: Snap[] = [];
+  let lo = 0;
+  let hi = arr.length - 1;
+  let checks = 0;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    checks += 1;
+    const states: CellState[] = arr.map((_, idx) => (idx >= lo && idx <= hi ? 'range' : 'eliminated'));
+    states[mid] = 'active';
+    if (arr[mid] === target) {
+      const found = [...states];
+      found[mid] = 'found';
+      snaps.push({ states: found, desc: `Middle value ${arr[mid]} equals ${target} — found at index ${mid} in just ${checks} checks! ✅` });
+      return snaps;
+    }
+    if (arr[mid] < target) {
+      snaps.push({ states, desc: `Window ${lo}–${hi}. Middle is ${arr[mid]} < ${target}, so the answer must be to the right — discard the left half.` });
+      lo = mid + 1;
+    } else {
+      snaps.push({ states, desc: `Window ${lo}–${hi}. Middle is ${arr[mid]} > ${target}, so the answer must be to the left — discard the right half.` });
+      hi = mid - 1;
+    }
+  }
+  snaps.push({ states: arr.map(() => 'eliminated'), desc: `The window is empty — ${target} is not in the list. ❌` });
+  return snaps;
+}
+
+export default function SearchingConcept() {
+  const [algorithm, setAlgorithm] = useState<'linear' | 'binary'>('binary');
+  const [target, setTarget] = useState(23);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const snaps = useMemo(
+    () => (algorithm === 'linear' ? linearSnaps(DATA, target) : binarySnaps(DATA, target)),
+    [algorithm, target],
+  );
+
+  useEffect(() => { setStep(0); setPlaying(false); }, [algorithm, target]);
+
+  useEffect(() => {
+    if (!playing) return;
+    if (step >= snaps.length - 1) { setPlaying(false); return; }
+    timer.current = setTimeout(() => setStep((s) => s + 1), 1000);
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, [playing, step, snaps.length]);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  const snap = snaps[step];
+
+  return (
+    <ConceptWrapper
+      title="Searching"
+      description="Searching means finding where a value lives in a collection. The smarter your method, the fewer items you have to look at."
+    >
+      <TableOfContents numbered>
+        <Section title="Two Ways to Find a Name">
+          <Typography variant="body2" paragraph>
+            Imagine looking for a name in a phone book. You could read <em>every</em> name from the start — that&apos;s <strong>linear search</strong>. Or you could flip to the middle, decide which half the name is in, and repeat — that&apos;s <strong>binary search</strong>. Binary search is dramatically faster, but it only works if the list is already <strong>sorted</strong>.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>🔎 Linear search — O(n):</strong> check each item one by one. Works on any list, sorted or not.
+              </Typography>
+              <Typography variant="body2">
+                <strong>⚡ Binary search — O(log n):</strong> repeatedly halve a sorted list. 1,000,000 items take only ~20 checks!
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Watch Them Search">
+          <Typography variant="body2" paragraph>
+            The list below is sorted. Pick a target and an algorithm, then step through to compare how many items each one has to look at.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="ds-controls">
+              <Button
+                variant={algorithm === 'linear' ? 'contained' : 'outlined'}
+                onClick={() => setAlgorithm('linear')}
+              >
+                Linear search
+              </Button>
+              <Button
+                variant={algorithm === 'binary' ? 'contained' : 'outlined'}
+                onClick={() => setAlgorithm('binary')}
+              >
+                Binary search
+              </Button>
+              <TextField
+                label="Target"
+                type="number"
+                size="small"
+                value={target}
+                onChange={(e) => setTarget(parseInt(e.target.value, 10) || 0)}
+                sx={{ width: 110 }}
+              />
+            </div>
+
+            <div className="cells-row">
+              {DATA.map((val, idx) => (
+                <div key={idx} className={`search-cell ${snap.states[idx]}`}>
+                  <span className="cell-index">{idx}</span>
+                  <span className="cell-value">{val}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="ds-controls">
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
+                Previous
+              </Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
+                Next
+              </Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
+                {playing ? 'Pause' : 'Play'}
+              </Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
+                Reset
+              </Button>
+            </div>
+
+            <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
+
+            <div className="ds-legend">
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Looking here</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#eff6ff', borderColor: '#93c5fd' }} /> Still in range</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f1f5f9', borderColor: '#cbd5e1', opacity: 0.5 }} /> Ruled out</span>
+            </div>
+          </div>
+
+          <Alert severity="info" sx={{ mt: 1 }}>
+            <Typography variant="body2">
+              Try searching for <strong>91</strong> (the last item) with both methods. Linear search checks all 11 cells; binary search finds it in about 4. The gap only grows as the list gets bigger.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="When to Use Which">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Use linear search</strong> when the list is small or unsorted, or you only search once.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Use binary search</strong> when the list is sorted and you&apos;ll search it many times — the speed is worth keeping it sorted.
+              </Typography>
+              <Typography variant="body2">
+                <strong>Remember the trade-off:</strong> binary search&apos;s speed depends entirely on the data already being in order.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/SearchingConcept.tsx
+++ b/components/pageComponents/Python/SearchingConcept.tsx
@@ -15,7 +15,7 @@ const DATA = [2, 5, 8, 12, 16, 23, 38, 45, 56, 72, 91];
 type CellState = '' | 'range' | 'active' | 'eliminated' | 'found';
 type Snap = { states: CellState[]; desc: string };
 
-// --- Static illustration data (a smaller, clearer list) --------------------
+// Static illustration data (a smaller, clearer list)
 const ILLUS = [3, 9, 14, 21, 28, 35, 42, 50];
 const ILLUS_TARGET_INDEX = 6; // value 42
 const linearBadges = ILLUS.map((_, i) => (i <= ILLUS_TARGET_INDEX ? i + 1 : null));
@@ -72,14 +72,14 @@ function binarySnaps(arr: number[], target: number): Snap[] {
     if (arr[mid] === target) {
       const found = [...states];
       found[mid] = 'found';
-      snaps.push({ states: found, desc: `The middle number ${arr[mid]} equals ${target} — found at position ${mid} in ${checks} checks.` });
+      snaps.push({ states: found, desc: `The middle number ${arr[mid]} equals ${target} — found in ${checks} checks.` });
       return snaps;
     }
     if (arr[mid] < target) {
-      snaps.push({ states, desc: `Middle value ${arr[mid]} is smaller than ${target}, so the answer must be to the right. Discard the entire left half.` });
+      snaps.push({ states, desc: `Middle is ${arr[mid]}, smaller than ${target}. Throw away the left half.` });
       lo = mid + 1;
     } else {
-      snaps.push({ states, desc: `Middle value ${arr[mid]} is larger than ${target}, so the answer must be to the left. Discard the entire right half.` });
+      snaps.push({ states, desc: `Middle is ${arr[mid]}, larger than ${target}. Throw away the right half.` });
       hi = mid - 1;
     }
   }
@@ -117,34 +117,30 @@ export default function SearchingConcept() {
   return (
     <ConceptWrapper
       title="Searching"
-      description="Searching is how a program finds where a value lives in a list. The smarter the method, the fewer items it has to examine."
+      description="Finding where a value lives in a list."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
-          <Typography variant="body2" paragraph>
-            Suppose you want to find a contact named Maria in your phone. You could scroll from the very top, name by name, until you reach hers. Or, because your contacts are in alphabetical order, you could jump to the middle, check whether you have gone too far, and keep narrowing the range.
-          </Typography>
-          <Typography variant="body2" paragraph>
-            Those are the two fundamental searching strategies, and computers rely on the same two ideas.
-          </Typography>
-
-          <CalloutBox title="Definition" type="info">
+          <CalloutBox title="Searching is elimination" type="key-concepts">
             <Typography variant="body2">
-              <strong>Searching</strong> is the process of looking through a collection to locate one specific item, or to determine that the item is not present.
+              Every search rules out items until only the answer is left. <strong>The faster you can rule items out, the faster you find what you want.</strong>
             </Typography>
           </CalloutBox>
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            That single idea separates the two strategies below: one rules out <em>one</em> item per step, the other rules out <em>half the list</em> per step.
+          </Typography>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="Linear Search: Check Every Item">
+        <Section title="Rule Out One at a Time (Linear Search)">
           <Typography variant="body2" paragraph>
-            The most direct method is to start at the beginning and examine every item in turn until the target is found. This is the equivalent of reading a grocery list from top to bottom looking for &quot;milk.&quot;
+            Check each item from the start until you find the target. Works on any list.
           </Typography>
 
           <div className="ds-viz">
             <div className="illus">
-              <div className="illus-label">Searching for 42 — linear search examines each box in order:</div>
+              <div className="illus-label">Finding 42 — one check per item:</div>
               <div className="illus-cells">
                 {ILLUS.map((val, i) => (
                   <div key={i} className={`illus-cell ${i === ILLUS_TARGET_INDEX ? 'target' : linearBadges[i] ? 'hit' : 'dim'}`}>
@@ -153,26 +149,20 @@ export default function SearchingConcept() {
                   </div>
                 ))}
               </div>
-              <p className="ds-caption">Reaching 42 took 7 checks. The numbered badges show the order of examination.</p>
+              <p className="ds-caption">7 checks to reach 42.</p>
             </div>
           </div>
-
-          <CalloutBox title="Trade-off" type="warning">
-            <Typography variant="body2">
-              Linear search works on any list, sorted or unsorted. The downside is that for a long list, an item near the end requires examining nearly everything.
-            </Typography>
-          </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Binary Search: Halve the Range Each Step">
+        <Section title="Rule Out Half at a Time (Binary Search)">
           <Typography variant="body2" paragraph>
-            When the list is sorted, a far more efficient approach is available. Examine the middle item. If it is smaller than the target, discard the entire left half; if it is larger, discard the entire right half. Repeat on whatever remains. Each examination eliminates half of the remaining items.
+            On a <strong>sorted</strong> list, check the middle. Too small? Drop the left half. Too big? Drop the right half. Repeat. Each check halves what&apos;s left.
           </Typography>
 
           <div className="ds-viz">
             <div className="illus">
-              <div className="illus-label">Searching for 42 — binary search jumps to the middle of each remaining range:</div>
+              <div className="illus-label">Finding 42 — jump to the middle each time:</div>
               <div className="illus-cells">
                 {ILLUS.map((val, i) => {
                   const order = binaryOrder.indexOf(i);
@@ -186,53 +176,41 @@ export default function SearchingConcept() {
                   );
                 })}
               </div>
-              <p className="ds-caption">Reaching 42 took only 3 checks; everything else was eliminated without being examined.</p>
+              <p className="ds-caption">Only 3 checks to reach 42.</p>
             </div>
           </div>
 
-          <CalloutBox title="Prerequisite" type="warning">
+          <CalloutBox title="The catch" type="warning">
             <Typography variant="body2">
-              Binary search requires a <strong>sorted</strong> list. The core deduction — &quot;the answer must be to the left or right&quot; — depends entirely on the items being in order.
+              Binary search only works if the list is <strong>sorted</strong> — that&apos;s what lets you trust &quot;the answer must be on this side.&quot;
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Interactive Comparison">
+        <Section title="Try It">
           <Typography variant="body2" paragraph>
-            The list below is sorted. Choose a number to find and a strategy, then use Play or step through manually. The scoreboard updates instantly so you can compare how many checks each method needs for the same target.
+            Pick a target and a strategy. The scoreboard shows how many items each one rules out before finding the answer.
           </Typography>
 
           <div className="ds-viz">
             <div className="ds-controls">
-              <Button variant={algorithm === 'linear' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('linear')}>
-                Linear search
-              </Button>
-              <Button variant={algorithm === 'binary' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('binary')}>
-                Binary search
-              </Button>
-              <TextField
-                label="Find this number"
-                type="number"
-                size="small"
-                value={target}
-                onChange={(e) => setTarget(parseInt(e.target.value, 10) || 0)}
-                sx={{ width: 150 }}
-              />
+              <Button variant={algorithm === 'linear' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('linear')}>Linear</Button>
+              <Button variant={algorithm === 'binary' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('binary')}>Binary</Button>
+              <TextField label="Find" type="number" size="small" value={target} onChange={(e) => setTarget(parseInt(e.target.value, 10) || 0)} sx={{ width: 110 }} />
             </div>
 
-            {/* Live scoreboard */}
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
-              <Box sx={{ flex: 1, minWidth: 180, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'linear' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
-                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Linear search</Typography>
+              <Box sx={{ flex: 1, minWidth: 150, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'linear' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
+                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Linear</Typography>
                 <Typography variant="h6" sx={{ color: '#3b82f6', fontWeight: 700 }}>
-                  {linearResult.found ? `${linearResult.checks} checks` : `${linearResult.checks} checks (not found)`}
+                  {linearResult.found ? `${linearResult.checks} checks` : `${linearResult.checks} (not found)`}
                 </Typography>
               </Box>
-              <Box sx={{ flex: 1, minWidth: 180, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'binary' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
-                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Binary search</Typography>
+              <Box sx={{ flex: 1, minWidth: 150, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'binary' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
+                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Binary</Typography>
                 <Typography variant="h6" sx={{ color: '#8b5cf6', fontWeight: 700 }}>
-                  {binaryResult.found ? `${binaryResult.checks} checks` : `${binaryResult.checks} checks (not found)`}
+                  {binaryResult.found ? `${binaryResult.checks} checks` : `${binaryResult.checks} (not found)`}
                 </Typography>
               </Box>
             </Box>
@@ -247,45 +225,27 @@ export default function SearchingConcept() {
             </div>
 
             <div className="ds-controls">
-              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
-                Previous
-              </Button>
-              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
-                Next
-              </Button>
-              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
-                {playing ? 'Pause' : 'Play'}
-              </Button>
-              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
-                Reset
-              </Button>
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>Previous</Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>Next</Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>{playing ? 'Pause' : 'Play'}</Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>Reset</Button>
             </div>
 
             <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
-
-            <div className="ds-legend">
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Examining</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#eff6ff', borderColor: '#93c5fd' }} /> Still possible</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f1f5f9', borderColor: '#cbd5e1', opacity: 0.5 }} /> Eliminated</span>
-            </div>
           </div>
 
-          <CalloutBox title="Suggested experiment" type="success">
-            <Typography variant="body2">
-              Search for <strong>91</strong> (the last value) with each strategy and compare the scoreboard: linear search examines all 11 items, while binary search finds it in about 4. Then enter a value that is not present, such as <strong>50</strong>, to see how each method concludes the item is missing.
-            </Typography>
-          </CalloutBox>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            Try finding <strong>91</strong> with each strategy, then try <strong>50</strong> (not in the list).
+          </Typography>
         </Section>
 
         {/* 5 ----------------------------------------------------------------- */}
-        <Section title="Why Binary Search Scales So Well">
+        <Section title="Why Halving Wins">
           <Typography variant="body2" paragraph>
-            Each examination in binary search discards half of the remaining items. Halving repeatedly reduces even a very large list to a single candidate in a small number of steps.
+            Ruling out half the list each step adds up fast.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">Starting from 16 items, each check roughly halves what remains:</div>
             {[
               { left: 16, w: 100 },
               { left: 8, w: 50 },
@@ -294,40 +254,17 @@ export default function SearchingConcept() {
               { left: 1, w: 6.25 },
             ].map((row, i) => (
               <div className="halve-row" key={i}>
-                <span style={{ width: 70, fontSize: 13, color: '#475569' }}>Check {i + 1}</span>
+                <span style={{ width: 64, fontSize: 13, color: '#475569' }}>Check {i + 1}</span>
                 <span className="halve-bar" style={{ width: `${row.w}%` }}>{row.left} left</span>
               </div>
             ))}
-            <p className="ds-caption">16 items resolve in 4 checks. A list of 1,000,000 items requires only about 20.</p>
+            <p className="ds-caption">16 items: found in 4 checks. 1,000,000 items: about 20.</p>
           </div>
 
-          <CalloutBox title="Scaling behaviour" type="info">
+          <CalloutBox title="Connecting back" type="success">
             <Typography variant="body2">
-              Doubling the size of the list adds just one additional step to binary search. This growth rate is written as <strong>O(log n)</strong> and is covered in detail in <em>Algorithm Analysis &amp; Design</em>.
+              Same goal, very different speed — because binary search eliminates more per step. That is the whole point of searching: <strong>rule out as much as you can, as fast as you can.</strong>
             </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 6 ----------------------------------------------------------------- */}
-        <Section title="Real-World Examples">
-          <CalloutBox title="Where these strategies appear" type="key-concepts">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Dictionaries and phone books:</strong> flipping toward the middle rather than starting at page one is binary search performed by hand.</Typography>
-              <Typography variant="body2"><strong>Find on a page (Ctrl+F):</strong> scanning text item by item is linear search.</Typography>
-              <Typography variant="body2"><strong>Number-guessing games:</strong> a &quot;higher or lower&quot; strategy is binary search.</Typography>
-              <Typography variant="body2"><strong>Databases:</strong> data is kept sorted or indexed so lookups can use binary-search-style efficiency.</Typography>
-            </Box>
-          </CalloutBox>
-        </Section>
-
-        {/* 7 ----------------------------------------------------------------- */}
-        <Section title="Key Takeaways">
-          <CalloutBox title="Summary" type="success">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Linear search</strong> examines items one at a time. It is simple and works on any list, but is slow for long lists.</Typography>
-              <Typography variant="body2"><strong>Binary search</strong> repeatedly halves a sorted list, requiring far fewer checks.</Typography>
-              <Typography variant="body2"><strong>The trade-off:</strong> binary search&apos;s efficiency depends on the list being sorted in advance.</Typography>
-            </Box>
           </CalloutBox>
         </Section>
       </TableOfContents>

--- a/components/pageComponents/Python/SearchingConcept.tsx
+++ b/components/pageComponents/Python/SearchingConcept.tsx
@@ -15,15 +15,32 @@ const DATA = [2, 5, 8, 12, 16, 23, 38, 45, 56, 72, 91];
 type CellState = '' | 'range' | 'active' | 'eliminated' | 'found';
 type Snap = { states: CellState[]; desc: string };
 
-// --- Static illustration data (a smaller, friendlier list) -----------------
+// --- Static illustration data (a smaller, clearer list) --------------------
 const ILLUS = [3, 9, 14, 21, 28, 35, 42, 50];
 const ILLUS_TARGET_INDEX = 6; // value 42
-
-// Linear checks every cell from the left until it hits the target
 const linearBadges = ILLUS.map((_, i) => (i <= ILLUS_TARGET_INDEX ? i + 1 : null));
+const binaryOrder = [3, 5, 6]; // middles binary search would visit to reach index 6
 
-// Binary keeps halving: middle of [0,7]=3, middle of [4,7]=5, middle of [6,7]=6
-const binaryOrder = [3, 5, 6];
+function countLinear(target: number): { checks: number; found: boolean } {
+  for (let i = 0; i < DATA.length; i++) {
+    if (DATA[i] === target) return { checks: i + 1, found: true };
+  }
+  return { checks: DATA.length, found: false };
+}
+
+function countBinary(target: number): { checks: number; found: boolean } {
+  let lo = 0;
+  let hi = DATA.length - 1;
+  let checks = 0;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    checks += 1;
+    if (DATA[mid] === target) return { checks, found: true };
+    if (DATA[mid] < target) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  return { checks, found: false };
+}
 
 function linearSnaps(arr: number[], target: number): Snap[] {
   const snaps: Snap[] = [];
@@ -34,11 +51,11 @@ function linearSnaps(arr: number[], target: number): Snap[] {
     if (arr[i] === target) {
       const found: CellState[] = arr.map((_, idx) => (idx < i ? 'eliminated' : ''));
       found[i] = 'found';
-      snaps.push({ states: found, desc: `Found ${target} at position ${i}! That took ${i + 1} checks. ✅` });
+      snaps.push({ states: found, desc: `Found ${target} at position ${i}. That took ${i + 1} checks.` });
       return snaps;
     }
   }
-  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Checked every item — ${target} is not in the list. ❌` });
+  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Checked every item — ${target} is not in the list.` });
   return snaps;
 }
 
@@ -55,18 +72,18 @@ function binarySnaps(arr: number[], target: number): Snap[] {
     if (arr[mid] === target) {
       const found = [...states];
       found[mid] = 'found';
-      snaps.push({ states: found, desc: `The middle number ${arr[mid]} is exactly ${target} — found it at position ${mid} in just ${checks} checks! ✅` });
+      snaps.push({ states: found, desc: `The middle number ${arr[mid]} equals ${target} — found at position ${mid} in ${checks} checks.` });
       return snaps;
     }
     if (arr[mid] < target) {
-      snaps.push({ states, desc: `Look at the middle (${arr[mid]}). It's smaller than ${target}, so the answer must be to the right. Ignore the whole left half.` });
+      snaps.push({ states, desc: `Middle value ${arr[mid]} is smaller than ${target}, so the answer must be to the right. Discard the entire left half.` });
       lo = mid + 1;
     } else {
-      snaps.push({ states, desc: `Look at the middle (${arr[mid]}). It's bigger than ${target}, so the answer must be to the left. Ignore the whole right half.` });
+      snaps.push({ states, desc: `Middle value ${arr[mid]} is larger than ${target}, so the answer must be to the left. Discard the entire right half.` });
       hi = mid - 1;
     }
   }
-  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Nothing left to check — ${target} is not in the list. ❌` });
+  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Nothing left to check — ${target} is not in the list.` });
   return snaps;
 }
 
@@ -81,6 +98,8 @@ export default function SearchingConcept() {
     () => (algorithm === 'linear' ? linearSnaps(DATA, target) : binarySnaps(DATA, target)),
     [algorithm, target],
   );
+  const linearResult = useMemo(() => countLinear(target), [target]);
+  const binaryResult = useMemo(() => countBinary(target), [target]);
 
   useEffect(() => { setStep(0); setPlaying(false); }, [algorithm, target]);
 
@@ -98,96 +117,90 @@ export default function SearchingConcept() {
   return (
     <ConceptWrapper
       title="Searching"
-      description="Searching is how a program finds where something lives in a list. The smarter the method, the fewer things it has to look at."
+      description="Searching is how a program finds where a value lives in a list. The smarter the method, the fewer items it has to examine."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            You want to find your friend Maria&apos;s number in your phone. You could scroll from the very top, name by name, until you reach hers. Or — because your contacts are in <strong>alphabetical order</strong> — you could jump to the middle, see if you&apos;ve gone too far, and keep narrowing it down.
+            Suppose you want to find a contact named Maria in your phone. You could scroll from the very top, name by name, until you reach hers. Or, because your contacts are in alphabetical order, you could jump to the middle, check whether you have gone too far, and keep narrowing the range.
           </Typography>
           <Typography variant="body2" paragraph>
-            Those are the two big searching strategies, and computers use the exact same ideas.
+            Those are the two fundamental searching strategies, and computers rely on the same two ideas.
           </Typography>
 
-          <CalloutBox title="In plain English" type="info" icon="💡">
+          <CalloutBox title="Definition" type="info">
             <Typography variant="body2">
-              <strong>Searching</strong> = looking through a collection to find one specific item (or to find out it isn&apos;t there).
+              <strong>Searching</strong> is the process of looking through a collection to locate one specific item, or to determine that the item is not present.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="Way 1: Check Every Item (Linear Search)">
+        <Section title="Linear Search: Check Every Item">
           <Typography variant="body2" paragraph>
-            The simplest method: start at the beginning and look at <strong>every item one at a time</strong> until you find what you want. It&apos;s like reading a grocery list top to bottom looking for &quot;milk.&quot;
+            The most direct method is to start at the beginning and examine every item in turn until the target is found. This is the equivalent of reading a grocery list from top to bottom looking for &quot;milk.&quot;
           </Typography>
 
           <div className="ds-viz">
             <div className="illus">
-              <div className="illus-label">Looking for 42 — linear search checks each box in order:</div>
+              <div className="illus-label">Searching for 42 — linear search examines each box in order:</div>
               <div className="illus-cells">
                 {ILLUS.map((val, i) => (
-                  <div
-                    key={i}
-                    className={`illus-cell ${i === ILLUS_TARGET_INDEX ? 'target' : linearBadges[i] ? 'hit' : 'dim'}`}
-                  >
+                  <div key={i} className={`illus-cell ${i === ILLUS_TARGET_INDEX ? 'target' : linearBadges[i] ? 'hit' : 'dim'}`}>
                     {linearBadges[i] && <span className="viz-badge">{linearBadges[i]}</span>}
                     {val}
                   </div>
                 ))}
               </div>
-              <p className="ds-caption">It took 7 checks to reach 42. The numbered badges show the order it looked.</p>
+              <p className="ds-caption">Reaching 42 took 7 checks. The numbered badges show the order of examination.</p>
             </div>
           </div>
 
-          <CalloutBox title="The catch" type="warning" icon="⚠️">
+          <CalloutBox title="Trade-off" type="warning">
             <Typography variant="body2">
-              Linear search works on <strong>any</strong> list (sorted or messy), but if the list is long and your item is near the end, you do a <em>lot</em> of looking.
+              Linear search works on any list, sorted or unsorted. The downside is that for a long list, an item near the end requires examining nearly everything.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Way 2: Split in Half Every Time (Binary Search)">
+        <Section title="Binary Search: Halve the Range Each Step">
           <Typography variant="body2" paragraph>
-            If the list is already <strong>sorted</strong>, you can be much smarter. Look at the <strong>middle</strong> item. If it&apos;s too small, throw away the entire left half. If it&apos;s too big, throw away the entire right half. Repeat on what&apos;s left. Each look <strong>cuts the problem in half</strong>.
+            When the list is sorted, a far more efficient approach is available. Examine the middle item. If it is smaller than the target, discard the entire left half; if it is larger, discard the entire right half. Repeat on whatever remains. Each examination eliminates half of the remaining items.
           </Typography>
 
           <div className="ds-viz">
             <div className="illus">
-              <div className="illus-label">Looking for 42 — binary search jumps to the middle each time:</div>
+              <div className="illus-label">Searching for 42 — binary search jumps to the middle of each remaining range:</div>
               <div className="illus-cells">
                 {ILLUS.map((val, i) => {
                   const order = binaryOrder.indexOf(i);
                   const isTarget = i === ILLUS_TARGET_INDEX;
                   const checked = order !== -1;
                   return (
-                    <div
-                      key={i}
-                      className={`illus-cell ${isTarget ? 'target' : checked ? 'hit' : 'dim'}`}
-                    >
+                    <div key={i} className={`illus-cell ${isTarget ? 'target' : checked ? 'hit' : 'dim'}`}>
                       {checked && <span className="viz-badge binary">{order + 1}</span>}
                       {val}
                     </div>
                   );
                 })}
               </div>
-              <p className="ds-caption">Only 3 checks to reach 42 — it ignored everything else.</p>
+              <p className="ds-caption">Reaching 42 took only 3 checks; everything else was eliminated without being examined.</p>
             </div>
           </div>
 
-          <CalloutBox title="One important rule" type="warning" icon="📋">
+          <CalloutBox title="Prerequisite" type="warning">
             <Typography variant="body2">
-              Binary search <strong>only works on a sorted list</strong>. The whole trick — &quot;the answer must be to the left/right&quot; — falls apart if the items are out of order.
+              Binary search requires a <strong>sorted</strong> list. The core deduction — &quot;the answer must be to the left or right&quot; — depends entirely on the items being in order.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Try It Yourself">
+        <Section title="Interactive Comparison">
           <Typography variant="body2" paragraph>
-            The list below is sorted. Pick a number to find and a strategy, then press <strong>Play</strong> (or step through). Count how many items each method has to look at.
+            The list below is sorted. Choose a number to find and a strategy, then use Play or step through manually. The scoreboard updates instantly so you can compare how many checks each method needs for the same target.
           </Typography>
 
           <div className="ds-viz">
@@ -207,6 +220,22 @@ export default function SearchingConcept() {
                 sx={{ width: 150 }}
               />
             </div>
+
+            {/* Live scoreboard */}
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+              <Box sx={{ flex: 1, minWidth: 180, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'linear' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
+                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Linear search</Typography>
+                <Typography variant="h6" sx={{ color: '#3b82f6', fontWeight: 700 }}>
+                  {linearResult.found ? `${linearResult.checks} checks` : `${linearResult.checks} checks (not found)`}
+                </Typography>
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 180, p: 1.5, borderRadius: 2, border: '1px solid', borderColor: algorithm === 'binary' ? '#2563eb' : '#e2e8f0', bgcolor: '#f8fafc' }}>
+                <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>Binary search</Typography>
+                <Typography variant="h6" sx={{ color: '#8b5cf6', fontWeight: 700 }}>
+                  {binaryResult.found ? `${binaryResult.checks} checks` : `${binaryResult.checks} checks (not found)`}
+                </Typography>
+              </Box>
+            </Box>
 
             <div className="cells-row">
               {DATA.map((val, idx) => (
@@ -235,28 +264,28 @@ export default function SearchingConcept() {
             <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
 
             <div className="ds-legend">
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Looking here</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Examining</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#eff6ff', borderColor: '#93c5fd' }} /> Still possible</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found it</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f1f5f9', borderColor: '#cbd5e1', opacity: 0.5 }} /> Ruled out</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f1f5f9', borderColor: '#cbd5e1', opacity: 0.5 }} /> Eliminated</span>
             </div>
           </div>
 
-          <CalloutBox title="Try this" type="success" icon="🧪">
+          <CalloutBox title="Suggested experiment" type="success">
             <Typography variant="body2">
-              Search for <strong>91</strong> (the last number) with each strategy. Linear search looks at all 11 boxes; binary search finds it in about 4. Then try a number that isn&apos;t there, like <strong>50</strong>, and watch how each one gives up.
+              Search for <strong>91</strong> (the last value) with each strategy and compare the scoreboard: linear search examines all 11 items, while binary search finds it in about 4. Then enter a value that is not present, such as <strong>50</strong>, to see how each method concludes the item is missing.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 5 ----------------------------------------------------------------- */}
-        <Section title="Why Binary Search Is So Fast">
+        <Section title="Why Binary Search Scales So Well">
           <Typography variant="body2" paragraph>
-            Every time binary search looks at the middle, it <strong>throws away half</strong> of what&apos;s left. Halving again and again shrinks even a huge list to nothing in just a handful of steps.
+            Each examination in binary search discards half of the remaining items. Halving repeatedly reduces even a very large list to a single candidate in a small number of steps.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">Starting with 16 items, each check roughly halves what&apos;s left:</div>
+            <div className="illus-label">Starting from 16 items, each check roughly halves what remains:</div>
             {[
               { left: 16, w: 100 },
               { left: 8, w: 50 },
@@ -269,35 +298,35 @@ export default function SearchingConcept() {
                 <span className="halve-bar" style={{ width: `${row.w}%` }}>{row.left} left</span>
               </div>
             ))}
-            <p className="ds-caption">16 items → found in 4 checks. A list of 1,000,000 items? Only about 20 checks.</p>
+            <p className="ds-caption">16 items resolve in 4 checks. A list of 1,000,000 items requires only about 20.</p>
           </div>
 
-          <CalloutBox title="The headline number" type="success" icon="⚡">
+          <CalloutBox title="Scaling behaviour" type="info">
             <Typography variant="body2">
-              Doubling the size of the list adds just <strong>one more step</strong> to binary search. Programmers call this <strong>O(log n)</strong> — but the plain-English version is &quot;ridiculously fast, even on giant lists.&quot; (More on these labels in <em>Algorithm Analysis &amp; Design</em>.)
+              Doubling the size of the list adds just one additional step to binary search. This growth rate is written as <strong>O(log n)</strong> and is covered in detail in <em>Algorithm Analysis &amp; Design</em>.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 6 ----------------------------------------------------------------- */}
-        <Section title="Where You've Seen This">
-          <CalloutBox title="Everyday examples" type="key-concepts" icon="🌍">
+        <Section title="Real-World Examples">
+          <CalloutBox title="Where these strategies appear" type="key-concepts">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>📖 A dictionary or phone book:</strong> you flip toward the middle, not page 1 — that&apos;s binary search by hand.</Typography>
-              <Typography variant="body2"><strong>🔍 &quot;Find on this page&quot; (Ctrl+F):</strong> scans the text item by item — linear search.</Typography>
-              <Typography variant="body2"><strong>🎯 A guess-the-number game:</strong> &quot;higher or lower?&quot; is binary search.</Typography>
-              <Typography variant="body2"><strong>🗄️ Databases:</strong> keep data sorted/indexed so lookups can use binary-search-style speed.</Typography>
+              <Typography variant="body2"><strong>Dictionaries and phone books:</strong> flipping toward the middle rather than starting at page one is binary search performed by hand.</Typography>
+              <Typography variant="body2"><strong>Find on a page (Ctrl+F):</strong> scanning text item by item is linear search.</Typography>
+              <Typography variant="body2"><strong>Number-guessing games:</strong> a &quot;higher or lower&quot; strategy is binary search.</Typography>
+              <Typography variant="body2"><strong>Databases:</strong> data is kept sorted or indexed so lookups can use binary-search-style efficiency.</Typography>
             </Box>
           </CalloutBox>
         </Section>
 
         {/* 7 ----------------------------------------------------------------- */}
         <Section title="Key Takeaways">
-          <CalloutBox title="Remember these" type="success" icon="✅">
+          <CalloutBox title="Summary" type="success">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Linear search</strong> checks items one by one. Simple, works on any list, but slow on long ones.</Typography>
-              <Typography variant="body2"><strong>Binary search</strong> repeatedly splits a <em>sorted</em> list in half. Far fewer checks.</Typography>
-              <Typography variant="body2"><strong>The trade-off:</strong> binary search&apos;s speed depends entirely on the list already being in order.</Typography>
+              <Typography variant="body2"><strong>Linear search</strong> examines items one at a time. It is simple and works on any list, but is slow for long lists.</Typography>
+              <Typography variant="body2"><strong>Binary search</strong> repeatedly halves a sorted list, requiring far fewer checks.</Typography>
+              <Typography variant="body2"><strong>The trade-off:</strong> binary search&apos;s efficiency depends on the list being sorted in advance.</Typography>
             </Box>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/SearchingConcept.tsx
+++ b/components/pageComponents/Python/SearchingConcept.tsx
@@ -267,6 +267,28 @@ export default function SearchingConcept() {
             </Typography>
           </CalloutBox>
         </Section>
+
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="When You'd Actually Use This">
+          <Typography variant="body2" paragraph>
+            Searching shows up any time a program has a pile of data and needs to find one specific thing in it:
+          </Typography>
+
+          <CalloutBox title="Everyday programming situations" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Logging in:</strong> checking the email you typed against millions of stored accounts.</Typography>
+              <Typography variant="body2"><strong>&quot;Username already taken&quot;:</strong> searching existing users when someone signs up.</Typography>
+              <Typography variant="body2"><strong>Scanning a barcode:</strong> finding that product in the store&apos;s catalog.</Typography>
+              <Typography variant="body2"><strong>Autocomplete:</strong> finding the entries that match what you&apos;ve typed so far.</Typography>
+            </Box>
+          </CalloutBox>
+
+          <CalloutBox title="Why the sorted version matters" type="info">
+            <Typography variant="body2">
+              The reason apps keep data sorted or &quot;indexed&quot; — a leaderboard, a contacts list, a database — is so lookups can use binary search and stay instant even with millions of records. That speed is only possible because the data is in order.
+            </Typography>
+          </CalloutBox>
+        </Section>
       </TableOfContents>
     </ConceptWrapper>
   );

--- a/components/pageComponents/Python/SearchingConcept.tsx
+++ b/components/pageComponents/Python/SearchingConcept.tsx
@@ -5,10 +5,9 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
@@ -16,16 +15,26 @@ const DATA = [2, 5, 8, 12, 16, 23, 38, 45, 56, 72, 91];
 type CellState = '' | 'range' | 'active' | 'eliminated' | 'found';
 type Snap = { states: CellState[]; desc: string };
 
+// --- Static illustration data (a smaller, friendlier list) -----------------
+const ILLUS = [3, 9, 14, 21, 28, 35, 42, 50];
+const ILLUS_TARGET_INDEX = 6; // value 42
+
+// Linear checks every cell from the left until it hits the target
+const linearBadges = ILLUS.map((_, i) => (i <= ILLUS_TARGET_INDEX ? i + 1 : null));
+
+// Binary keeps halving: middle of [0,7]=3, middle of [4,7]=5, middle of [6,7]=6
+const binaryOrder = [3, 5, 6];
+
 function linearSnaps(arr: number[], target: number): Snap[] {
   const snaps: Snap[] = [];
   for (let i = 0; i < arr.length; i++) {
     const states: CellState[] = arr.map((_, idx) => (idx < i ? 'eliminated' : ''));
     states[i] = 'active';
-    snaps.push({ states, desc: `Check index ${i}: is ${arr[i]} the value we want (${target})?` });
+    snaps.push({ states, desc: `Check position ${i}: is ${arr[i]} the number we want (${target})?` });
     if (arr[i] === target) {
       const found: CellState[] = arr.map((_, idx) => (idx < i ? 'eliminated' : ''));
       found[i] = 'found';
-      snaps.push({ states: found, desc: `Found ${target} at index ${i}! It took ${i + 1} checks. ✅` });
+      snaps.push({ states: found, desc: `Found ${target} at position ${i}! That took ${i + 1} checks. ✅` });
       return snaps;
     }
   }
@@ -46,18 +55,18 @@ function binarySnaps(arr: number[], target: number): Snap[] {
     if (arr[mid] === target) {
       const found = [...states];
       found[mid] = 'found';
-      snaps.push({ states: found, desc: `Middle value ${arr[mid]} equals ${target} — found at index ${mid} in just ${checks} checks! ✅` });
+      snaps.push({ states: found, desc: `The middle number ${arr[mid]} is exactly ${target} — found it at position ${mid} in just ${checks} checks! ✅` });
       return snaps;
     }
     if (arr[mid] < target) {
-      snaps.push({ states, desc: `Window ${lo}–${hi}. Middle is ${arr[mid]} < ${target}, so the answer must be to the right — discard the left half.` });
+      snaps.push({ states, desc: `Look at the middle (${arr[mid]}). It's smaller than ${target}, so the answer must be to the right. Ignore the whole left half.` });
       lo = mid + 1;
     } else {
-      snaps.push({ states, desc: `Window ${lo}–${hi}. Middle is ${arr[mid]} > ${target}, so the answer must be to the left — discard the right half.` });
+      snaps.push({ states, desc: `Look at the middle (${arr[mid]}). It's bigger than ${target}, so the answer must be to the left. Ignore the whole right half.` });
       hi = mid - 1;
     }
   }
-  snaps.push({ states: arr.map(() => 'eliminated'), desc: `The window is empty — ${target} is not in the list. ❌` });
+  snaps.push({ states: arr.map(() => 'eliminated'), desc: `Nothing left to check — ${target} is not in the list. ❌` });
   return snaps;
 }
 
@@ -89,52 +98,113 @@ export default function SearchingConcept() {
   return (
     <ConceptWrapper
       title="Searching"
-      description="Searching means finding where a value lives in a collection. The smarter your method, the fewer items you have to look at."
+      description="Searching is how a program finds where something lives in a list. The smarter the method, the fewer things it has to look at."
     >
       <TableOfContents numbered>
-        <Section title="Two Ways to Find a Name">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            Imagine looking for a name in a phone book. You could read <em>every</em> name from the start — that&apos;s <strong>linear search</strong>. Or you could flip to the middle, decide which half the name is in, and repeat — that&apos;s <strong>binary search</strong>. Binary search is dramatically faster, but it only works if the list is already <strong>sorted</strong>.
+            You want to find your friend Maria&apos;s number in your phone. You could scroll from the very top, name by name, until you reach hers. Or — because your contacts are in <strong>alphabetical order</strong> — you could jump to the middle, see if you&apos;ve gone too far, and keep narrowing it down.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            Those are the two big searching strategies, and computers use the exact same ideas.
           </Typography>
 
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>🔎 Linear search — O(n):</strong> check each item one by one. Works on any list, sorted or not.
-              </Typography>
-              <Typography variant="body2">
-                <strong>⚡ Binary search — O(log n):</strong> repeatedly halve a sorted list. 1,000,000 items take only ~20 checks!
-              </Typography>
-            </Box>
-          </ConceptInfoCard>
+          <CalloutBox title="In plain English" type="info" icon="💡">
+            <Typography variant="body2">
+              <strong>Searching</strong> = looking through a collection to find one specific item (or to find out it isn&apos;t there).
+            </Typography>
+          </CalloutBox>
         </Section>
 
-        <Section title="Watch Them Search">
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="Way 1: Check Every Item (Linear Search)">
           <Typography variant="body2" paragraph>
-            The list below is sorted. Pick a target and an algorithm, then step through to compare how many items each one has to look at.
+            The simplest method: start at the beginning and look at <strong>every item one at a time</strong> until you find what you want. It&apos;s like reading a grocery list top to bottom looking for &quot;milk.&quot;
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="illus">
+              <div className="illus-label">Looking for 42 — linear search checks each box in order:</div>
+              <div className="illus-cells">
+                {ILLUS.map((val, i) => (
+                  <div
+                    key={i}
+                    className={`illus-cell ${i === ILLUS_TARGET_INDEX ? 'target' : linearBadges[i] ? 'hit' : 'dim'}`}
+                  >
+                    {linearBadges[i] && <span className="viz-badge">{linearBadges[i]}</span>}
+                    {val}
+                  </div>
+                ))}
+              </div>
+              <p className="ds-caption">It took 7 checks to reach 42. The numbered badges show the order it looked.</p>
+            </div>
+          </div>
+
+          <CalloutBox title="The catch" type="warning" icon="⚠️">
+            <Typography variant="body2">
+              Linear search works on <strong>any</strong> list (sorted or messy), but if the list is long and your item is near the end, you do a <em>lot</em> of looking.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 3 ----------------------------------------------------------------- */}
+        <Section title="Way 2: Split in Half Every Time (Binary Search)">
+          <Typography variant="body2" paragraph>
+            If the list is already <strong>sorted</strong>, you can be much smarter. Look at the <strong>middle</strong> item. If it&apos;s too small, throw away the entire left half. If it&apos;s too big, throw away the entire right half. Repeat on what&apos;s left. Each look <strong>cuts the problem in half</strong>.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="illus">
+              <div className="illus-label">Looking for 42 — binary search jumps to the middle each time:</div>
+              <div className="illus-cells">
+                {ILLUS.map((val, i) => {
+                  const order = binaryOrder.indexOf(i);
+                  const isTarget = i === ILLUS_TARGET_INDEX;
+                  const checked = order !== -1;
+                  return (
+                    <div
+                      key={i}
+                      className={`illus-cell ${isTarget ? 'target' : checked ? 'hit' : 'dim'}`}
+                    >
+                      {checked && <span className="viz-badge binary">{order + 1}</span>}
+                      {val}
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="ds-caption">Only 3 checks to reach 42 — it ignored everything else.</p>
+            </div>
+          </div>
+
+          <CalloutBox title="One important rule" type="warning" icon="📋">
+            <Typography variant="body2">
+              Binary search <strong>only works on a sorted list</strong>. The whole trick — &quot;the answer must be to the left/right&quot; — falls apart if the items are out of order.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Try It Yourself">
+          <Typography variant="body2" paragraph>
+            The list below is sorted. Pick a number to find and a strategy, then press <strong>Play</strong> (or step through). Count how many items each method has to look at.
           </Typography>
 
           <div className="ds-viz">
             <div className="ds-controls">
-              <Button
-                variant={algorithm === 'linear' ? 'contained' : 'outlined'}
-                onClick={() => setAlgorithm('linear')}
-              >
+              <Button variant={algorithm === 'linear' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('linear')}>
                 Linear search
               </Button>
-              <Button
-                variant={algorithm === 'binary' ? 'contained' : 'outlined'}
-                onClick={() => setAlgorithm('binary')}
-              >
+              <Button variant={algorithm === 'binary' ? 'contained' : 'outlined'} onClick={() => setAlgorithm('binary')}>
                 Binary search
               </Button>
               <TextField
-                label="Target"
+                label="Find this number"
                 type="number"
                 size="small"
                 value={target}
                 onChange={(e) => setTarget(parseInt(e.target.value, 10) || 0)}
-                sx={{ width: 110 }}
+                sx={{ width: 150 }}
               />
             </div>
 
@@ -166,33 +236,70 @@ export default function SearchingConcept() {
 
             <div className="ds-legend">
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fef9c3', borderColor: '#facc15' }} /> Looking here</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#eff6ff', borderColor: '#93c5fd' }} /> Still in range</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#eff6ff', borderColor: '#93c5fd' }} /> Still possible</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Found it</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f1f5f9', borderColor: '#cbd5e1', opacity: 0.5 }} /> Ruled out</span>
             </div>
           </div>
 
-          <Alert severity="info" sx={{ mt: 1 }}>
+          <CalloutBox title="Try this" type="success" icon="🧪">
             <Typography variant="body2">
-              Try searching for <strong>91</strong> (the last item) with both methods. Linear search checks all 11 cells; binary search finds it in about 4. The gap only grows as the list gets bigger.
+              Search for <strong>91</strong> (the last number) with each strategy. Linear search looks at all 11 boxes; binary search finds it in about 4. Then try a number that isn&apos;t there, like <strong>50</strong>, and watch how each one gives up.
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
-        <Section title="When to Use Which">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Use linear search</strong> when the list is small or unsorted, or you only search once.
-              </Typography>
-              <Typography variant="body2">
-                <strong>Use binary search</strong> when the list is sorted and you&apos;ll search it many times — the speed is worth keeping it sorted.
-              </Typography>
-              <Typography variant="body2">
-                <strong>Remember the trade-off:</strong> binary search&apos;s speed depends entirely on the data already being in order.
-              </Typography>
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="Why Binary Search Is So Fast">
+          <Typography variant="body2" paragraph>
+            Every time binary search looks at the middle, it <strong>throws away half</strong> of what&apos;s left. Halving again and again shrinks even a huge list to nothing in just a handful of steps.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="illus-label">Starting with 16 items, each check roughly halves what&apos;s left:</div>
+            {[
+              { left: 16, w: 100 },
+              { left: 8, w: 50 },
+              { left: 4, w: 25 },
+              { left: 2, w: 12.5 },
+              { left: 1, w: 6.25 },
+            ].map((row, i) => (
+              <div className="halve-row" key={i}>
+                <span style={{ width: 70, fontSize: 13, color: '#475569' }}>Check {i + 1}</span>
+                <span className="halve-bar" style={{ width: `${row.w}%` }}>{row.left} left</span>
+              </div>
+            ))}
+            <p className="ds-caption">16 items → found in 4 checks. A list of 1,000,000 items? Only about 20 checks.</p>
+          </div>
+
+          <CalloutBox title="The headline number" type="success" icon="⚡">
+            <Typography variant="body2">
+              Doubling the size of the list adds just <strong>one more step</strong> to binary search. Programmers call this <strong>O(log n)</strong> — but the plain-English version is &quot;ridiculously fast, even on giant lists.&quot; (More on these labels in <em>Algorithm Analysis &amp; Design</em>.)
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="Where You've Seen This">
+          <CalloutBox title="Everyday examples" type="key-concepts" icon="🌍">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>📖 A dictionary or phone book:</strong> you flip toward the middle, not page 1 — that&apos;s binary search by hand.</Typography>
+              <Typography variant="body2"><strong>🔍 &quot;Find on this page&quot; (Ctrl+F):</strong> scans the text item by item — linear search.</Typography>
+              <Typography variant="body2"><strong>🎯 A guess-the-number game:</strong> &quot;higher or lower?&quot; is binary search.</Typography>
+              <Typography variant="body2"><strong>🗄️ Databases:</strong> keep data sorted/indexed so lookups can use binary-search-style speed.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
+        </Section>
+
+        {/* 7 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Remember these" type="success" icon="✅">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Linear search</strong> checks items one by one. Simple, works on any list, but slow on long ones.</Typography>
+              <Typography variant="body2"><strong>Binary search</strong> repeatedly splits a <em>sorted</em> list in half. Far fewer checks.</Typography>
+              <Typography variant="body2"><strong>The trade-off:</strong> binary search&apos;s speed depends entirely on the list already being in order.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/SortingConcept.tsx
+++ b/components/pageComponents/Python/SortingConcept.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type BarState = '' | 'compare' | 'swap' | 'sorted';
+type Snap = { values: number[]; states: BarState[]; desc: string };
+
+function buildBubbleSnaps(input: number[]): Snap[] {
+  const arr = [...input];
+  const n = arr.length;
+  const snaps: Snap[] = [];
+  for (let i = 0; i < n - 1; i++) {
+    for (let j = 0; j < n - 1 - i; j++) {
+      const states: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
+      states[j] = 'compare';
+      states[j + 1] = 'compare';
+      snaps.push({ values: [...arr], states, desc: `Compare neighbors ${arr[j]} and ${arr[j + 1]}.` });
+      if (arr[j] > arr[j + 1]) {
+        const a = arr[j];
+        const b = arr[j + 1];
+        arr[j] = b;
+        arr[j + 1] = a;
+        const s2: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
+        s2[j] = 'swap';
+        s2[j + 1] = 'swap';
+        snaps.push({ values: [...arr], states: s2, desc: `${a} is bigger than ${b}, so swap them — the bigger value drifts right.` });
+      }
+    }
+  }
+  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), desc: 'No more swaps needed — the list is fully sorted! ✅' });
+  return snaps;
+}
+
+function randomArray(size = 8): number[] {
+  return Array.from({ length: size }, () => Math.floor(Math.random() * 90) + 10);
+}
+
+const INITIAL = [40, 8, 70, 25, 90, 15, 55, 33];
+
+export default function SortingConcept() {
+  const [base, setBase] = useState<number[]>(INITIAL);
+  const snaps = useMemo(() => buildBubbleSnaps(base), [base]);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => { setStep(0); setPlaying(false); }, [base]);
+
+  useEffect(() => {
+    if (!playing) return;
+    if (step >= snaps.length - 1) { setPlaying(false); return; }
+    timer.current = setTimeout(() => setStep((s) => s + 1), 650);
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, [playing, step, snaps.length]);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  const snap = snaps[step];
+  const maxVal = Math.max(...snap.values);
+
+  return (
+    <ConceptWrapper
+      title="Sorting"
+      description="Sorting arranges items into order. Watching the values shuffle into place makes the strategy easy to see."
+    >
+      <TableOfContents numbered>
+        <Section title="Sorting Cards in Your Hand">
+          <Typography variant="body2" paragraph>
+            When you tidy a hand of playing cards, you naturally compare neighbors and swap the ones that are out of order. <strong>Bubble sort</strong> does exactly that: it walks across the list comparing each pair, swapping when needed, so the largest value &quot;bubbles&quot; up to the end on every pass.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              How Bubble Sort Thinks
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2"><strong>1.</strong> Compare the first two items</Typography>
+              <Typography variant="body2"><strong>2.</strong> If they&apos;re in the wrong order, swap them</Typography>
+              <Typography variant="body2"><strong>3.</strong> Move one step right and repeat to the end</Typography>
+              <Typography variant="body2"><strong>4.</strong> Repeat the whole pass until no swaps are needed</Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Watch It Sort">
+          <Typography variant="body2" paragraph>
+            Each bar is a number — taller means bigger. Step through to see the comparisons and swaps, and watch the green &quot;already sorted&quot; zone grow from the right.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="bars-area">
+              {snap.values.map((val, idx) => (
+                <div
+                  key={idx}
+                  className={`bar ${snap.states[idx]}`}
+                  style={{ height: `${(val / maxVal) * 100}%` }}
+                >
+                  {val}
+                </div>
+              ))}
+            </div>
+
+            <div className="ds-controls" style={{ marginTop: 16 }}>
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
+                Previous
+              </Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
+                Next
+              </Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
+                {playing ? 'Pause' : 'Play'}
+              </Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
+                Reset
+              </Button>
+              <Button variant="outlined" onClick={() => setBase(randomArray())}>
+                Shuffle
+              </Button>
+            </div>
+
+            <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
+
+            <div className="ds-legend">
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fbbf24' }} /> Comparing</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f87171' }} /> Swapping</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#34d399' }} /> In final position</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Unsorted</span>
+            </div>
+          </div>
+        </Section>
+
+        <Section title="Bubble Sort Is Simple but Slow">
+          <Typography variant="body2" paragraph>
+            Bubble sort is wonderful for <em>learning</em> because you can see every step. But it compares almost every pair, so it runs in <strong>O(n²)</strong> time — double the data and it does roughly four times the work.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Bubble / Insertion / Selection sort — O(n²):</strong> easy to understand, fine for tiny lists
+              </Typography>
+              <Typography variant="body2">
+                <strong>Merge / Quick / Heap sort — O(n log n):</strong> what real programs use for large data
+              </Typography>
+              <Typography variant="body2">
+                <strong>Python&apos;s built-in <code>sorted()</code></strong> uses a highly optimized O(n log n) sort — in real code, reach for that.
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Faster sorts like merge sort use the <strong>divide &amp; conquer</strong> strategy from Algorithm Analysis &amp; Design: split the list in half, sort each half, then merge them back together.
+            </Typography>
+          </Alert>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/SortingConcept.tsx
+++ b/components/pageComponents/Python/SortingConcept.tsx
@@ -23,7 +23,7 @@ function buildBubbleSnaps(input: number[]): Snap[] {
       const states: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
       states[j] = 'compare';
       states[j + 1] = 'compare';
-      snaps.push({ values: [...arr], states, kind: 'compare', desc: `Compare the two highlighted neighbours: ${arr[j]} and ${arr[j + 1]}.` });
+      snaps.push({ values: [...arr], states, kind: 'compare', desc: `Compare ${arr[j]} and ${arr[j + 1]}.` });
       if (arr[j] > arr[j + 1]) {
         const a = arr[j];
         const b = arr[j + 1];
@@ -32,11 +32,11 @@ function buildBubbleSnaps(input: number[]): Snap[] {
         const s2: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
         s2[j] = 'swap';
         s2[j + 1] = 'swap';
-        snaps.push({ values: [...arr], states: s2, kind: 'swap', desc: `${a} is greater than ${b}, so they are swapped — the larger value moves to the right.` });
+        snaps.push({ values: [...arr], states: s2, kind: 'swap', desc: `${a} is bigger than ${b}, so swap them.` });
       }
     }
   }
-  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), kind: 'done', desc: 'No further swaps are needed — the list is fully sorted.' });
+  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), kind: 'done', desc: 'No pairs left to fix — the list is sorted.' });
   return snaps;
 }
 
@@ -66,41 +66,34 @@ export default function SortingConcept() {
 
   const snap = snaps[step];
   const maxVal = Math.max(...snap.values);
-
-  // Live tallies up to the current step
   const comparisons = snaps.slice(0, step + 1).filter((s) => s.kind === 'compare').length;
   const swaps = snaps.slice(0, step + 1).filter((s) => s.kind === 'swap').length;
 
   return (
     <ConceptWrapper
       title="Sorting"
-      description="Sorting arranges a list into order. Watching the values move into place makes the underlying strategy easy to follow."
+      description="Putting a list in order."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
-          <Typography variant="body2" paragraph>
-            Consider tidying a hand of playing cards. Most people do something simple without thinking about it: they glance at two adjacent cards and, if those cards are out of order, swap them. Repeat that enough times and the whole hand ends up sorted.
-          </Typography>
-          <Typography variant="body2" paragraph>
-            That everyday habit is almost exactly the algorithm known as <strong>bubble sort</strong>.
-          </Typography>
-
-          <CalloutBox title="Definition" type="info">
+          <CalloutBox title="Sorting is fixing pairs" type="key-concepts">
             <Typography variant="body2">
-              <strong>Sorting</strong> is the process of rearranging a list so its items follow a defined order — smallest to largest, A to Z, oldest to newest, and so on.
+              If two neighbours are out of order, swap them. <strong>Repeat that one move until no pair is out of order — now the whole list is sorted.</strong>
             </Typography>
           </CalloutBox>
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            That is exactly how most people sort a hand of cards, and it is exactly how <strong>bubble sort</strong> works.
+          </Typography>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="The Core Move: Compare Two Neighbours">
+        <Section title="The One Move">
           <Typography variant="body2" paragraph>
-            Bubble sort performs only one basic operation: it looks at two adjacent items and swaps them if the one on the left is larger.
+            Look at two neighbours. If the left one is bigger, swap them. The whole algorithm is just this move, repeated across the list again and again.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">Two neighbours are out of order, so they are swapped:</div>
             <div className="cards-compare">
               <div className="play-card big">7</div>
               <span className="compare-symbol">&gt;</span>
@@ -109,40 +102,17 @@ export default function SortingConcept() {
               <div className="play-card">3</div>
               <div className="play-card big">7</div>
             </div>
-            <p className="ds-caption">7 is greater than 3, so they trade places. The larger value ends up on the right.</p>
+            <p className="ds-caption">7 is bigger than 3, so they swap. The bigger value moves right.</p>
           </div>
-
-          <CalloutBox title="The full algorithm in four steps" type="key-concepts">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
-              <Typography variant="body2"><strong>1.</strong> Begin at the left with the first two items.</Typography>
-              <Typography variant="body2"><strong>2.</strong> If they are out of order, swap them.</Typography>
-              <Typography variant="body2"><strong>3.</strong> Move one position to the right and repeat, all the way to the end.</Typography>
-              <Typography variant="body2"><strong>4.</strong> Return to the start and perform another pass; continue until a full pass makes no swaps.</Typography>
-            </Box>
-          </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Why It Is Called Bubble Sort">
+        <Section title="Try It">
           <Typography variant="body2" paragraph>
-            On each left-to-right pass, the largest remaining value is swapped rightward until it can move no further. The largest value appears to rise to the end of the list, much like a bubble rising to the surface. After the first pass the largest value is in its final position; after the second pass the next-largest is settled beside it, and so on.
-          </Typography>
-
-          <CalloutBox title="Watch the sorted region" type="info">
-            <Typography variant="body2">
-              In the visualization below, every value that has reached its final position turns <strong>green</strong>. This sorted region grows from the right with each pass until the entire list is green.
-            </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Interactive Visualization">
-          <Typography variant="body2" paragraph>
-            Each bar represents a number; taller means larger. Step through or press Play to watch the comparisons, the swaps, and the sorted region growing from the right. The counters track the total work performed so far.
+            Each bar is a number. Step through and watch the same move repeat. Bars that reach their final spot turn <strong>green</strong>, growing from the right.
           </Typography>
 
           <div className="ds-viz">
-            {/* Live counters */}
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
               <Box sx={{ p: 1.25, px: 2, borderRadius: 2, bgcolor: '#fffbeb', border: '1px solid #fcd34d' }}>
                 <Typography variant="caption" sx={{ color: '#92400e', display: 'block' }}>Comparisons</Typography>
@@ -163,69 +133,27 @@ export default function SortingConcept() {
             </div>
 
             <div className="ds-controls" style={{ marginTop: 16 }}>
-              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>
-                Previous
-              </Button>
-              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>
-                Next
-              </Button>
-              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>
-                {playing ? 'Pause' : 'Play'}
-              </Button>
-              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>
-                Reset
-              </Button>
-              <Button variant="outlined" onClick={() => setBase(randomArray())}>
-                Shuffle
-              </Button>
+              <Button variant="outlined" onClick={() => { setPlaying(false); setStep((s) => Math.max(0, s - 1)); }} disabled={step === 0}>Previous</Button>
+              <Button variant="contained" onClick={() => { setPlaying(false); setStep((s) => Math.min(snaps.length - 1, s + 1)); }} disabled={step >= snaps.length - 1}>Next</Button>
+              <Button variant="outlined" onClick={() => setPlaying((p) => !p)} disabled={step >= snaps.length - 1}>{playing ? 'Pause' : 'Play'}</Button>
+              <Button variant="text" color="secondary" onClick={() => { setPlaying(false); setStep(0); }}>Reset</Button>
+              <Button variant="outlined" onClick={() => setBase(randomArray())}>Shuffle</Button>
             </div>
 
             <p className="ds-output"><strong>Step {step + 1} / {snaps.length}:</strong> {snap.desc}</p>
-
-            <div className="ds-legend">
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fbbf24' }} /> Comparing</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f87171' }} /> Swapping</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#34d399' }} /> In final position</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Not yet sorted</span>
-            </div>
           </div>
-
-          <CalloutBox title="Suggested experiment" type="success">
-            <Typography variant="body2">
-              Press <strong>Shuffle</strong> a few times and predict which bar will turn green first. It is always the tallest bar still in play. Note how an already-sorted list still requires a full pass of comparisons to confirm it is sorted.
-            </Typography>
-          </CalloutBox>
         </Section>
 
-        {/* 5 ----------------------------------------------------------------- */}
-        <Section title="How Efficient Is Bubble Sort?">
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Simple, but Slow">
           <Typography variant="body2" paragraph>
-            Bubble sort is excellent for learning because every move is visible, but it is not efficient. It compares nearly every pair of items, so the work grows quickly: doubling the list size roughly quadruples the number of comparisons.
+            Because it fixes just one pair at a time, bubble sort does a lot of work — double the list and it does about four times as much. It is great for learning, not for real data.
           </Typography>
 
-          <CalloutBox title="What production code uses" type="info">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Bubble, insertion, and selection sort</strong> are easy to understand and acceptable for very small lists. Their growth rate is O(n&sup2;).</Typography>
-              <Typography variant="body2"><strong>Merge, quick, and heap sort</strong> are what real software uses for large data. Their growth rate is O(n log n).</Typography>
-              <Typography variant="body2"><strong>In practice,</strong> you rarely write a sort by hand in Python — you call the built-in <code>sorted()</code>, which uses a highly optimized O(n log n) algorithm.</Typography>
-            </Box>
-          </CalloutBox>
-
-          <CalloutBox title="The strategy behind fast sorts" type="key-concepts">
+          <CalloutBox title="In practice" type="info">
             <Typography variant="body2">
-              Efficient sorts such as merge sort use <strong>divide and conquer</strong>: split the list in half, sort each half, then merge the two sorted halves. This strategy is discussed further in <em>Algorithm Analysis &amp; Design</em>.
+              Real programs use faster sorts (merge, quick) or just call Python&apos;s built-in <code>sorted()</code>. See <em>Algorithm Analysis &amp; Design</em> for why &quot;one pair at a time&quot; doesn&apos;t scale.
             </Typography>
-          </CalloutBox>
-        </Section>
-
-        {/* 6 ----------------------------------------------------------------- */}
-        <Section title="Key Takeaways">
-          <CalloutBox title="Summary" type="success">
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Sorting</strong> arranges a list into order and makes searching and many other tasks easier.</Typography>
-              <Typography variant="body2"><strong>Bubble sort</strong> repeatedly compares neighbours and swaps them, moving large values toward the end.</Typography>
-              <Typography variant="body2"><strong>It is simple but slow</strong> — ideal for learning, while production code relies on faster sorts such as <code>sorted()</code>.</Typography>
-            </Box>
           </CalloutBox>
         </Section>
       </TableOfContents>

--- a/components/pageComponents/Python/SortingConcept.tsx
+++ b/components/pageComponents/Python/SortingConcept.tsx
@@ -156,6 +156,28 @@ export default function SortingConcept() {
             </Typography>
           </CalloutBox>
         </Section>
+
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="When You'd Actually Use This">
+          <Typography variant="body2" paragraph>
+            Almost any time a program shows a list to a person, it shows it in some order — and putting it in that order is sorting:
+          </Typography>
+
+          <CalloutBox title="Everyday programming situations" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A feed or inbox:</strong> newest posts and emails shown first.</Typography>
+              <Typography variant="body2"><strong>A leaderboard:</strong> highest scores ranked at the top.</Typography>
+              <Typography variant="body2"><strong>A contacts list or music library:</strong> sorted A–Z.</Typography>
+              <Typography variant="body2"><strong>Shopping results:</strong> &quot;price: low to high&quot; or &quot;most relevant first.&quot;</Typography>
+            </Box>
+          </CalloutBox>
+
+          <CalloutBox title="Sorting helps searching" type="success">
+            <Typography variant="body2">
+              Sorting is also a setup step: once a list is in order, you can find things in it with fast binary search. The main choice you make is <em>what</em> to sort by — date, price, name, score.
+            </Typography>
+          </CalloutBox>
+        </Section>
       </TableOfContents>
     </ConceptWrapper>
   );

--- a/components/pageComponents/Python/SortingConcept.tsx
+++ b/components/pageComponents/Python/SortingConcept.tsx
@@ -11,7 +11,8 @@ import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
 type BarState = '' | 'compare' | 'swap' | 'sorted';
-type Snap = { values: number[]; states: BarState[]; desc: string };
+type SnapKind = 'compare' | 'swap' | 'done';
+type Snap = { values: number[]; states: BarState[]; desc: string; kind: SnapKind };
 
 function buildBubbleSnaps(input: number[]): Snap[] {
   const arr = [...input];
@@ -22,7 +23,7 @@ function buildBubbleSnaps(input: number[]): Snap[] {
       const states: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
       states[j] = 'compare';
       states[j + 1] = 'compare';
-      snaps.push({ values: [...arr], states, desc: `Compare the two yellow neighbors: ${arr[j]} and ${arr[j + 1]}.` });
+      snaps.push({ values: [...arr], states, kind: 'compare', desc: `Compare the two highlighted neighbours: ${arr[j]} and ${arr[j + 1]}.` });
       if (arr[j] > arr[j + 1]) {
         const a = arr[j];
         const b = arr[j + 1];
@@ -31,11 +32,11 @@ function buildBubbleSnaps(input: number[]): Snap[] {
         const s2: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
         s2[j] = 'swap';
         s2[j + 1] = 'swap';
-        snaps.push({ values: [...arr], states: s2, desc: `${a} is bigger than ${b}, so swap them — the bigger number moves right.` });
+        snaps.push({ values: [...arr], states: s2, kind: 'swap', desc: `${a} is greater than ${b}, so they are swapped — the larger value moves to the right.` });
       }
     }
   }
-  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), desc: 'No swaps left to make — the list is fully sorted! ✅' });
+  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), kind: 'done', desc: 'No further swaps are needed — the list is fully sorted.' });
   return snaps;
 }
 
@@ -66,77 +67,93 @@ export default function SortingConcept() {
   const snap = snaps[step];
   const maxVal = Math.max(...snap.values);
 
+  // Live tallies up to the current step
+  const comparisons = snaps.slice(0, step + 1).filter((s) => s.kind === 'compare').length;
+  const swaps = snaps.slice(0, step + 1).filter((s) => s.kind === 'swap').length;
+
   return (
     <ConceptWrapper
       title="Sorting"
-      description="Sorting means putting a list in order. Seeing the values slide into place makes the strategy easy to follow."
+      description="Sorting arranges a list into order. Watching the values move into place makes the underlying strategy easy to follow."
     >
       <TableOfContents numbered>
         {/* 1 ----------------------------------------------------------------- */}
         <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            Imagine you&apos;re holding a messy hand of playing cards and you want them in order. Most people do something simple without thinking about it: they glance at two cards next to each other and, if they&apos;re in the wrong order, swap them. Do that enough times and the whole hand ends up sorted.
+            Consider tidying a hand of playing cards. Most people do something simple without thinking about it: they glance at two adjacent cards and, if those cards are out of order, swap them. Repeat that enough times and the whole hand ends up sorted.
           </Typography>
           <Typography variant="body2" paragraph>
-            That everyday habit is almost exactly the algorithm called <strong>bubble sort</strong>.
+            That everyday habit is almost exactly the algorithm known as <strong>bubble sort</strong>.
           </Typography>
 
-          <CalloutBox title="In plain English" type="info" icon="💡">
+          <CalloutBox title="Definition" type="info">
             <Typography variant="body2">
-              <strong>Sorting</strong> = rearranging a list so the items are in order (smallest to largest, A to Z, oldest to newest, and so on).
+              <strong>Sorting</strong> is the process of rearranging a list so its items follow a defined order — smallest to largest, A to Z, oldest to newest, and so on.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 2 ----------------------------------------------------------------- */}
-        <Section title="The One Move: Compare Two Neighbors">
+        <Section title="The Core Move: Compare Two Neighbours">
           <Typography variant="body2" paragraph>
-            Bubble sort only ever does one tiny thing: it looks at <strong>two side-by-side items</strong> and swaps them if the left one is bigger.
+            Bubble sort performs only one basic operation: it looks at two adjacent items and swaps them if the one on the left is larger.
           </Typography>
 
           <div className="ds-viz">
-            <div className="illus-label">Two neighbors are out of order, so swap them:</div>
+            <div className="illus-label">Two neighbours are out of order, so they are swapped:</div>
             <div className="cards-compare">
               <div className="play-card big">7</div>
               <span className="compare-symbol">&gt;</span>
               <div className="play-card">3</div>
-              <span className="swap-arrows">⇄</span>
+              <span className="swap-arrows">&#8644;</span>
               <div className="play-card">3</div>
               <div className="play-card big">7</div>
             </div>
-            <p className="ds-caption">7 is bigger than 3, so they trade places. The bigger number ends up on the right.</p>
+            <p className="ds-caption">7 is greater than 3, so they trade places. The larger value ends up on the right.</p>
           </div>
 
-          <CalloutBox title="The whole algorithm, in 4 steps" type="key-concepts" icon="📋">
+          <CalloutBox title="The full algorithm in four steps" type="key-concepts">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
-              <Typography variant="body2"><strong>1.</strong> Start at the left with the first two items.</Typography>
-              <Typography variant="body2"><strong>2.</strong> If they&apos;re in the wrong order, swap them.</Typography>
-              <Typography variant="body2"><strong>3.</strong> Shuffle one step to the right and repeat, all the way to the end.</Typography>
-              <Typography variant="body2"><strong>4.</strong> Go back to the start and do another pass — keep going until a pass makes no swaps.</Typography>
+              <Typography variant="body2"><strong>1.</strong> Begin at the left with the first two items.</Typography>
+              <Typography variant="body2"><strong>2.</strong> If they are out of order, swap them.</Typography>
+              <Typography variant="body2"><strong>3.</strong> Move one position to the right and repeat, all the way to the end.</Typography>
+              <Typography variant="body2"><strong>4.</strong> Return to the start and perform another pass; continue until a full pass makes no swaps.</Typography>
             </Box>
           </CalloutBox>
         </Section>
 
         {/* 3 ----------------------------------------------------------------- */}
-        <Section title="Why It's Called 'Bubble' Sort">
+        <Section title="Why It Is Called Bubble Sort">
           <Typography variant="body2" paragraph>
-            On each left-to-right pass, the biggest remaining number keeps getting swapped rightward until it can&apos;t go any further. It looks like the largest value <strong>bubbles up</strong> to the end of the list, like a bubble rising to the top of a glass. After the first pass the biggest is parked at the far right; after the second pass the next-biggest is parked next to it, and so on.
+            On each left-to-right pass, the largest remaining value is swapped rightward until it can move no further. The largest value appears to rise to the end of the list, much like a bubble rising to the surface. After the first pass the largest value is in its final position; after the second pass the next-largest is settled beside it, and so on.
           </Typography>
 
-          <CalloutBox title="Watch for the green zone" type="success" icon="🫧">
+          <CalloutBox title="Watch the sorted region" type="info">
             <Typography variant="body2">
-              In the visualizer below, every number that has &quot;bubbled&quot; into its final spot turns <strong>green</strong>. The green zone grows from the right with every pass until the whole list is green.
+              In the visualization below, every value that has reached its final position turns <strong>green</strong>. This sorted region grows from the right with each pass until the entire list is green.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 4 ----------------------------------------------------------------- */}
-        <Section title="Watch It Sort">
+        <Section title="Interactive Visualization">
           <Typography variant="body2" paragraph>
-            Each bar is a number — taller means bigger. Step through (or press Play) to watch the comparisons, the swaps, and the green &quot;done&quot; zone growing from the right.
+            Each bar represents a number; taller means larger. Step through or press Play to watch the comparisons, the swaps, and the sorted region growing from the right. The counters track the total work performed so far.
           </Typography>
 
           <div className="ds-viz">
+            {/* Live counters */}
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+              <Box sx={{ p: 1.25, px: 2, borderRadius: 2, bgcolor: '#fffbeb', border: '1px solid #fcd34d' }}>
+                <Typography variant="caption" sx={{ color: '#92400e', display: 'block' }}>Comparisons</Typography>
+                <Typography variant="h6" sx={{ fontWeight: 700, color: '#b45309' }}>{comparisons}</Typography>
+              </Box>
+              <Box sx={{ p: 1.25, px: 2, borderRadius: 2, bgcolor: '#fef2f2', border: '1px solid #fca5a5' }}>
+                <Typography variant="caption" sx={{ color: '#991b1b', display: 'block' }}>Swaps</Typography>
+                <Typography variant="h6" sx={{ fontWeight: 700, color: '#b91c1c' }}>{swaps}</Typography>
+              </Box>
+            </Box>
+
             <div className="bars-area">
               {snap.values.map((val, idx) => (
                 <div key={idx} className={`bar ${snap.states[idx]}`} style={{ height: `${(val / maxVal) * 100}%` }}>
@@ -169,45 +186,45 @@ export default function SortingConcept() {
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fbbf24' }} /> Comparing</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f87171' }} /> Swapping</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#34d399' }} /> In final position</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Not sorted yet</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Not yet sorted</span>
             </div>
           </div>
 
-          <CalloutBox title="Try this" type="success" icon="🧪">
+          <CalloutBox title="Suggested experiment" type="success">
             <Typography variant="body2">
-              Press <strong>Shuffle</strong> a few times and predict which bar will turn green first. (Hint: it&apos;s always the tallest one still in play.)
+              Press <strong>Shuffle</strong> a few times and predict which bar will turn green first. It is always the tallest bar still in play. Note how an already-sorted list still requires a full pass of comparisons to confirm it is sorted.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 5 ----------------------------------------------------------------- */}
-        <Section title="Is Bubble Sort Fast?">
+        <Section title="How Efficient Is Bubble Sort?">
           <Typography variant="body2" paragraph>
-            Honestly? No. Bubble sort is fantastic for <em>learning</em> because you can see every move — but it compares almost every pair of items, so it gets slow quickly. Double the list and it does roughly <strong>four times</strong> the work.
+            Bubble sort is excellent for learning because every move is visible, but it is not efficient. It compares nearly every pair of items, so the work grows quickly: doubling the list size roughly quadruples the number of comparisons.
           </Typography>
 
-          <CalloutBox title="What real programs use" type="info" icon="🚀">
+          <CalloutBox title="What production code uses" type="info">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Bubble / insertion / selection sort:</strong> easy to understand, fine for tiny lists. (&quot;Slow&quot; — O(n²).)</Typography>
-              <Typography variant="body2"><strong>Merge / quick / heap sort:</strong> what real software uses for big lists. (&quot;Fast&quot; — O(n log n).)</Typography>
-              <Typography variant="body2"><strong>In actual Python code,</strong> you almost never write a sort yourself — you call the built-in <code>sorted()</code>, which uses a highly optimized fast sort.</Typography>
+              <Typography variant="body2"><strong>Bubble, insertion, and selection sort</strong> are easy to understand and acceptable for very small lists. Their growth rate is O(n&sup2;).</Typography>
+              <Typography variant="body2"><strong>Merge, quick, and heap sort</strong> are what real software uses for large data. Their growth rate is O(n log n).</Typography>
+              <Typography variant="body2"><strong>In practice,</strong> you rarely write a sort by hand in Python — you call the built-in <code>sorted()</code>, which uses a highly optimized O(n log n) algorithm.</Typography>
             </Box>
           </CalloutBox>
 
-          <CalloutBox title="The clever trick behind fast sorts" type="key-concepts" icon="✂️">
+          <CalloutBox title="The strategy behind fast sorts" type="key-concepts">
             <Typography variant="body2">
-              Fast sorts like merge sort use <strong>divide &amp; conquer</strong>: split the list in half, sort each half, then merge the two sorted halves back together. You can read more about that strategy in <em>Algorithm Analysis &amp; Design</em>.
+              Efficient sorts such as merge sort use <strong>divide and conquer</strong>: split the list in half, sort each half, then merge the two sorted halves. This strategy is discussed further in <em>Algorithm Analysis &amp; Design</em>.
             </Typography>
           </CalloutBox>
         </Section>
 
         {/* 6 ----------------------------------------------------------------- */}
         <Section title="Key Takeaways">
-          <CalloutBox title="Remember these" type="success" icon="✅">
+          <CalloutBox title="Summary" type="success">
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
-              <Typography variant="body2"><strong>Sorting</strong> puts a list in order; it makes searching and many other tasks easier.</Typography>
-              <Typography variant="body2"><strong>Bubble sort</strong> repeatedly compares neighbors and swaps them, &quot;bubbling&quot; big values to the end.</Typography>
-              <Typography variant="body2"><strong>It&apos;s simple but slow</strong> — great for learning, but real code uses faster sorts like <code>sorted()</code>.</Typography>
+              <Typography variant="body2"><strong>Sorting</strong> arranges a list into order and makes searching and many other tasks easier.</Typography>
+              <Typography variant="body2"><strong>Bubble sort</strong> repeatedly compares neighbours and swaps them, moving large values toward the end.</Typography>
+              <Typography variant="body2"><strong>It is simple but slow</strong> — ideal for learning, while production code relies on faster sorts such as <code>sorted()</code>.</Typography>
             </Box>
           </CalloutBox>
         </Section>

--- a/components/pageComponents/Python/SortingConcept.tsx
+++ b/components/pageComponents/Python/SortingConcept.tsx
@@ -4,10 +4,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
@@ -23,7 +22,7 @@ function buildBubbleSnaps(input: number[]): Snap[] {
       const states: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
       states[j] = 'compare';
       states[j + 1] = 'compare';
-      snaps.push({ values: [...arr], states, desc: `Compare neighbors ${arr[j]} and ${arr[j + 1]}.` });
+      snaps.push({ values: [...arr], states, desc: `Compare the two yellow neighbors: ${arr[j]} and ${arr[j + 1]}.` });
       if (arr[j] > arr[j + 1]) {
         const a = arr[j];
         const b = arr[j + 1];
@@ -32,11 +31,11 @@ function buildBubbleSnaps(input: number[]): Snap[] {
         const s2: BarState[] = arr.map((_, idx) => (idx >= n - i ? 'sorted' : ''));
         s2[j] = 'swap';
         s2[j + 1] = 'swap';
-        snaps.push({ values: [...arr], states: s2, desc: `${a} is bigger than ${b}, so swap them — the bigger value drifts right.` });
+        snaps.push({ values: [...arr], states: s2, desc: `${a} is bigger than ${b}, so swap them — the bigger number moves right.` });
       }
     }
   }
-  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), desc: 'No more swaps needed — the list is fully sorted! ✅' });
+  snaps.push({ values: [...arr], states: arr.map(() => 'sorted'), desc: 'No swaps left to make — the list is fully sorted! ✅' });
   return snaps;
 }
 
@@ -70,40 +69,77 @@ export default function SortingConcept() {
   return (
     <ConceptWrapper
       title="Sorting"
-      description="Sorting arranges items into order. Watching the values shuffle into place makes the strategy easy to see."
+      description="Sorting means putting a list in order. Seeing the values slide into place makes the strategy easy to follow."
     >
       <TableOfContents numbered>
-        <Section title="Sorting Cards in Your Hand">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            When you tidy a hand of playing cards, you naturally compare neighbors and swap the ones that are out of order. <strong>Bubble sort</strong> does exactly that: it walks across the list comparing each pair, swapping when needed, so the largest value &quot;bubbles&quot; up to the end on every pass.
+            Imagine you&apos;re holding a messy hand of playing cards and you want them in order. Most people do something simple without thinking about it: they glance at two cards next to each other and, if they&apos;re in the wrong order, swap them. Do that enough times and the whole hand ends up sorted.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            That everyday habit is almost exactly the algorithm called <strong>bubble sort</strong>.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              How Bubble Sort Thinks
+          <CalloutBox title="In plain English" type="info" icon="💡">
+            <Typography variant="body2">
+              <strong>Sorting</strong> = rearranging a list so the items are in order (smallest to largest, A to Z, oldest to newest, and so on).
             </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2"><strong>1.</strong> Compare the first two items</Typography>
-              <Typography variant="body2"><strong>2.</strong> If they&apos;re in the wrong order, swap them</Typography>
-              <Typography variant="body2"><strong>3.</strong> Move one step right and repeat to the end</Typography>
-              <Typography variant="body2"><strong>4.</strong> Repeat the whole pass until no swaps are needed</Typography>
-            </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
         </Section>
 
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="The One Move: Compare Two Neighbors">
+          <Typography variant="body2" paragraph>
+            Bubble sort only ever does one tiny thing: it looks at <strong>two side-by-side items</strong> and swaps them if the left one is bigger.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="illus-label">Two neighbors are out of order, so swap them:</div>
+            <div className="cards-compare">
+              <div className="play-card big">7</div>
+              <span className="compare-symbol">&gt;</span>
+              <div className="play-card">3</div>
+              <span className="swap-arrows">⇄</span>
+              <div className="play-card">3</div>
+              <div className="play-card big">7</div>
+            </div>
+            <p className="ds-caption">7 is bigger than 3, so they trade places. The bigger number ends up on the right.</p>
+          </div>
+
+          <CalloutBox title="The whole algorithm, in 4 steps" type="key-concepts" icon="📋">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
+              <Typography variant="body2"><strong>1.</strong> Start at the left with the first two items.</Typography>
+              <Typography variant="body2"><strong>2.</strong> If they&apos;re in the wrong order, swap them.</Typography>
+              <Typography variant="body2"><strong>3.</strong> Shuffle one step to the right and repeat, all the way to the end.</Typography>
+              <Typography variant="body2"><strong>4.</strong> Go back to the start and do another pass — keep going until a pass makes no swaps.</Typography>
+            </Box>
+          </CalloutBox>
+        </Section>
+
+        {/* 3 ----------------------------------------------------------------- */}
+        <Section title="Why It's Called 'Bubble' Sort">
+          <Typography variant="body2" paragraph>
+            On each left-to-right pass, the biggest remaining number keeps getting swapped rightward until it can&apos;t go any further. It looks like the largest value <strong>bubbles up</strong> to the end of the list, like a bubble rising to the top of a glass. After the first pass the biggest is parked at the far right; after the second pass the next-biggest is parked next to it, and so on.
+          </Typography>
+
+          <CalloutBox title="Watch for the green zone" type="success" icon="🫧">
+            <Typography variant="body2">
+              In the visualizer below, every number that has &quot;bubbled&quot; into its final spot turns <strong>green</strong>. The green zone grows from the right with every pass until the whole list is green.
+            </Typography>
+          </CalloutBox>
+        </Section>
+
+        {/* 4 ----------------------------------------------------------------- */}
         <Section title="Watch It Sort">
           <Typography variant="body2" paragraph>
-            Each bar is a number — taller means bigger. Step through to see the comparisons and swaps, and watch the green &quot;already sorted&quot; zone grow from the right.
+            Each bar is a number — taller means bigger. Step through (or press Play) to watch the comparisons, the swaps, and the green &quot;done&quot; zone growing from the right.
           </Typography>
 
           <div className="ds-viz">
             <div className="bars-area">
               {snap.values.map((val, idx) => (
-                <div
-                  key={idx}
-                  className={`bar ${snap.states[idx]}`}
-                  style={{ height: `${(val / maxVal) * 100}%` }}
-                >
+                <div key={idx} className={`bar ${snap.states[idx]}`} style={{ height: `${(val / maxVal) * 100}%` }}>
                   {val}
                 </div>
               ))}
@@ -133,35 +169,47 @@ export default function SortingConcept() {
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fbbf24' }} /> Comparing</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#f87171' }} /> Swapping</span>
               <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#34d399' }} /> In final position</span>
-              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Unsorted</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#93c5fd' }} /> Not sorted yet</span>
             </div>
           </div>
+
+          <CalloutBox title="Try this" type="success" icon="🧪">
+            <Typography variant="body2">
+              Press <strong>Shuffle</strong> a few times and predict which bar will turn green first. (Hint: it&apos;s always the tallest one still in play.)
+            </Typography>
+          </CalloutBox>
         </Section>
 
-        <Section title="Bubble Sort Is Simple but Slow">
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="Is Bubble Sort Fast?">
           <Typography variant="body2" paragraph>
-            Bubble sort is wonderful for <em>learning</em> because you can see every step. But it compares almost every pair, so it runs in <strong>O(n²)</strong> time — double the data and it does roughly four times the work.
+            Honestly? No. Bubble sort is fantastic for <em>learning</em> because you can see every move — but it compares almost every pair of items, so it gets slow quickly. Double the list and it does roughly <strong>four times</strong> the work.
           </Typography>
 
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Bubble / Insertion / Selection sort — O(n²):</strong> easy to understand, fine for tiny lists
-              </Typography>
-              <Typography variant="body2">
-                <strong>Merge / Quick / Heap sort — O(n log n):</strong> what real programs use for large data
-              </Typography>
-              <Typography variant="body2">
-                <strong>Python&apos;s built-in <code>sorted()</code></strong> uses a highly optimized O(n log n) sort — in real code, reach for that.
-              </Typography>
+          <CalloutBox title="What real programs use" type="info" icon="🚀">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Bubble / insertion / selection sort:</strong> easy to understand, fine for tiny lists. (&quot;Slow&quot; — O(n²).)</Typography>
+              <Typography variant="body2"><strong>Merge / quick / heap sort:</strong> what real software uses for big lists. (&quot;Fast&quot; — O(n log n).)</Typography>
+              <Typography variant="body2"><strong>In actual Python code,</strong> you almost never write a sort yourself — you call the built-in <code>sorted()</code>, which uses a highly optimized fast sort.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
 
-          <Alert severity="info" sx={{ mt: 2 }}>
+          <CalloutBox title="The clever trick behind fast sorts" type="key-concepts" icon="✂️">
             <Typography variant="body2">
-              Faster sorts like merge sort use the <strong>divide &amp; conquer</strong> strategy from Algorithm Analysis &amp; Design: split the list in half, sort each half, then merge them back together.
+              Fast sorts like merge sort use <strong>divide &amp; conquer</strong>: split the list in half, sort each half, then merge the two sorted halves back together. You can read more about that strategy in <em>Algorithm Analysis &amp; Design</em>.
             </Typography>
-          </Alert>
+          </CalloutBox>
+        </Section>
+
+        {/* 6 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Remember these" type="success" icon="✅">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Sorting</strong> puts a list in order; it makes searching and many other tasks easier.</Typography>
+              <Typography variant="body2"><strong>Bubble sort</strong> repeatedly compares neighbors and swaps them, &quot;bubbling&quot; big values to the end.</Typography>
+              <Typography variant="body2"><strong>It&apos;s simple but slow</strong> — great for learning, but real code uses faster sorts like <code>sorted()</code>.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/StackConcept.tsx
+++ b/components/pageComponents/Python/StackConcept.tsx
@@ -6,10 +6,9 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
 import '../../../styles/dataStructures.css';
 
@@ -17,9 +16,9 @@ type Item = { id: number; value: string };
 
 export default function StackConcept() {
   const [stack, setStack] = useState<Item[]>([
-    { id: 1, value: '🍽️ 3' },
-    { id: 2, value: '🍽️ 7' },
-    { id: 3, value: '🍽️ 5' },
+    { id: 1, value: '3' },
+    { id: 2, value: '7' },
+    { id: 3, value: '5' },
   ]);
   const [nextId, setNextId] = useState(4);
   const [input, setInput] = useState('');
@@ -27,29 +26,29 @@ export default function StackConcept() {
 
   const push = () => {
     const value = input.trim() === '' ? String(Math.floor(Math.random() * 90) + 10) : input.trim();
-    setStack((prev) => [...prev, { id: nextId, value: `🍽️ ${value}` }]);
+    setStack((prev) => [...prev, { id: nextId, value }]);
     setNextId((n) => n + 1);
-    setMessage(`push(${value}) — placed a new plate on top`);
+    setMessage(`push(${value}) — a new item was placed on top.`);
     setInput('');
   };
 
   const pop = () => {
     if (stack.length === 0) {
-      setMessage('pop() — the stack is empty, nothing to remove!');
+      setMessage('pop() — the stack is empty, so there is nothing to remove.');
       return;
     }
     const top = stack[stack.length - 1];
     setStack((prev) => prev.slice(0, -1));
-    setMessage(`pop() → returned ${top.value.replace('🍽️ ', '')} (the top plate)`);
+    setMessage(`pop() returned ${top.value} — the item that was on top.`);
   };
 
   const peek = () => {
     if (stack.length === 0) {
-      setMessage('peek() — the stack is empty!');
+      setMessage('peek() — the stack is empty.');
       return;
     }
     const top = stack[stack.length - 1];
-    setMessage(`peek() → ${top.value.replace('🍽️ ', '')} (looks at the top without removing it)`);
+    setMessage(`peek() returned ${top.value} — the top item, which stays on the stack.`);
   };
 
   // Render top-of-stack first (visually on top)
@@ -58,35 +57,28 @@ export default function StackConcept() {
   return (
     <ConceptWrapper
       title="Stacks"
-      description="A stack is a Last-In, First-Out (LIFO) collection — the last thing you add is the first thing you take off."
+      description="A stack is a Last-In, First-Out (LIFO) collection: the most recently added item is the first one removed."
     >
       <TableOfContents numbered>
-        <Section title="Picture a Stack of Plates">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            The easiest way to understand a stack is to picture a <strong>stack of plates</strong> in a cupboard. You always add a clean plate to the <em>top</em>, and when you need one, you take it from the <em>top</em> too. You never pull a plate out from the middle or the bottom.
+            The clearest way to picture a stack is a pile of plates in a cupboard. A clean plate is always added to the <em>top</em>, and when one is needed it is taken from the <em>top</em> as well. Plates are never removed from the middle or the bottom.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              Last In, First Out (LIFO)
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>🍽️ Plates in a cupboard:</strong> the last plate stacked is the first one grabbed
-              </Typography>
-              <Typography variant="body2">
-                <strong>↩️ The Undo button:</strong> &quot;undo&quot; reverses your most recent action first
-              </Typography>
-              <Typography variant="body2">
-                <strong>🌐 Browser back button:</strong> returns you to the page you visited most recently
-              </Typography>
+          <CalloutBox title="Last In, First Out (LIFO)" type="info">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A pile of plates:</strong> the last plate added is the first one taken.</Typography>
+              <Typography variant="body2"><strong>The Undo command:</strong> &quot;undo&quot; reverses your most recent action first.</Typography>
+              <Typography variant="body2"><strong>The browser back button:</strong> returns you to the page you visited most recently.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
         </Section>
 
-        <Section title="Try It Yourself">
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="Interactive Stack">
           <Typography variant="body2" paragraph>
-            Use <strong>Push</strong> to add a plate to the top and <strong>Pop</strong> to take the top plate off. Watch how everything happens at the top — the bottom plates never move.
+            Use <strong>Push</strong> to add an item to the top and <strong>Pop</strong> to remove the top item. Note that every operation happens at the top — the lower items never move.
           </Typography>
 
           <div className="ds-viz">
@@ -106,7 +98,7 @@ export default function StackConcept() {
 
             <div className="stack-area">
               {displayItems.length === 0 && (
-                <div className="stack-empty">The stack is empty — push something on!</div>
+                <div className="stack-empty">The stack is empty — push an item to begin.</div>
               )}
               <div className="stack-column">
                 <AnimatePresence initial={false}>
@@ -121,61 +113,58 @@ export default function StackConcept() {
                       transition={{ duration: 0.25 }}
                     >
                       {item.value}
-                      {idx === 0 && <span className="stack-top-tag">← TOP</span>}
+                      {idx === 0 && <span className="stack-top-tag">&larr; top</span>}
                     </motion.div>
                   ))}
                 </AnimatePresence>
               </div>
               <div className="stack-base" />
             </div>
-            <p className="ds-caption">The dark bar is the bottom of the stack. New plates land on top.</p>
+            <p className="ds-caption">The dark bar is the bottom of the stack. New items are added on top.</p>
 
             {message && <p className="ds-output">{message}</p>}
           </div>
         </Section>
 
+        {/* 3 ----------------------------------------------------------------- */}
         <Section title="The Core Operations">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Typography variant="body2">
-                <strong>push(item)</strong> — add an item to the top of the stack
-              </Typography>
-              <Typography variant="body2">
-                <strong>pop()</strong> — remove and return the top item
-              </Typography>
-              <Typography variant="body2">
-                <strong>peek()</strong> — look at the top item without removing it
-              </Typography>
-              <Typography variant="body2">
-                <strong>is_empty()</strong> — check whether there is anything left
-              </Typography>
+          <CalloutBox title="Every stack supports four operations" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>push(item)</strong> — add an item to the top of the stack.</Typography>
+              <Typography variant="body2"><strong>pop()</strong> — remove and return the top item.</Typography>
+              <Typography variant="body2"><strong>peek()</strong> — read the top item without removing it.</Typography>
+              <Typography variant="body2"><strong>is_empty()</strong> — check whether any items remain.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
 
-          <Alert severity="info" sx={{ mt: 2 }}>
+          <CalloutBox title="Performance" type="info">
             <Typography variant="body2">
-              Because every operation happens at one end, push and pop are extremely fast — they take the same tiny amount of time no matter how tall the stack gets. (That&apos;s <strong>O(1)</strong>, which you can read about in Algorithm Analysis &amp; Design.)
+              Because every operation happens at one end, push and pop are very fast — they take the same constant amount of time no matter how tall the stack becomes. This is <strong>O(1)</strong>, described further in <em>Algorithm Analysis &amp; Design</em>.
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
-        <Section title="Where Stacks Show Up">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Function calls:</strong> the computer uses a &quot;call stack&quot; to remember where to return after each function finishes
-              </Typography>
-              <Typography variant="body2">
-                <strong>Undo / redo:</strong> editors stack up your actions so the most recent can be reversed first
-              </Typography>
-              <Typography variant="body2">
-                <strong>Matching brackets:</strong> compilers use a stack to check that every <code>(</code> has a matching <code>)</code>
-              </Typography>
-              <Typography variant="body2">
-                <strong>Back navigation:</strong> your browser history behaves like a stack of pages
-              </Typography>
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Where Stacks Are Used">
+          <CalloutBox title="Common applications" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Function calls:</strong> the computer uses a call stack to remember where to return after each function completes.</Typography>
+              <Typography variant="body2"><strong>Undo and redo:</strong> editors stack recorded actions so the most recent can be reversed first.</Typography>
+              <Typography variant="body2"><strong>Matching brackets:</strong> compilers use a stack to verify that every opening bracket has a matching closing bracket.</Typography>
+              <Typography variant="body2"><strong>Back navigation:</strong> browser history behaves like a stack of visited pages.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
+        </Section>
+
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Summary" type="success">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A stack is Last-In, First-Out:</strong> the newest item is removed first.</Typography>
+              <Typography variant="body2"><strong>All access happens at the top</strong> via push, pop, and peek.</Typography>
+              <Typography variant="body2"><strong>Operations are O(1)</strong> and underpin function calls, undo systems, and more.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/components/pageComponents/Python/StackConcept.tsx
+++ b/components/pageComponents/Python/StackConcept.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type Item = { id: number; value: string };
+
+export default function StackConcept() {
+  const [stack, setStack] = useState<Item[]>([
+    { id: 1, value: '🍽️ 3' },
+    { id: 2, value: '🍽️ 7' },
+    { id: 3, value: '🍽️ 5' },
+  ]);
+  const [nextId, setNextId] = useState(4);
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const push = () => {
+    const value = input.trim() === '' ? String(Math.floor(Math.random() * 90) + 10) : input.trim();
+    setStack((prev) => [...prev, { id: nextId, value: `🍽️ ${value}` }]);
+    setNextId((n) => n + 1);
+    setMessage(`push(${value}) — placed a new plate on top`);
+    setInput('');
+  };
+
+  const pop = () => {
+    if (stack.length === 0) {
+      setMessage('pop() — the stack is empty, nothing to remove!');
+      return;
+    }
+    const top = stack[stack.length - 1];
+    setStack((prev) => prev.slice(0, -1));
+    setMessage(`pop() → returned ${top.value.replace('🍽️ ', '')} (the top plate)`);
+  };
+
+  const peek = () => {
+    if (stack.length === 0) {
+      setMessage('peek() — the stack is empty!');
+      return;
+    }
+    const top = stack[stack.length - 1];
+    setMessage(`peek() → ${top.value.replace('🍽️ ', '')} (looks at the top without removing it)`);
+  };
+
+  // Render top-of-stack first (visually on top)
+  const displayItems = [...stack].reverse();
+
+  return (
+    <ConceptWrapper
+      title="Stacks"
+      description="A stack is a Last-In, First-Out (LIFO) collection — the last thing you add is the first thing you take off."
+    >
+      <TableOfContents numbered>
+        <Section title="Picture a Stack of Plates">
+          <Typography variant="body2" paragraph>
+            The easiest way to understand a stack is to picture a <strong>stack of plates</strong> in a cupboard. You always add a clean plate to the <em>top</em>, and when you need one, you take it from the <em>top</em> too. You never pull a plate out from the middle or the bottom.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Last In, First Out (LIFO)
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>🍽️ Plates in a cupboard:</strong> the last plate stacked is the first one grabbed
+              </Typography>
+              <Typography variant="body2">
+                <strong>↩️ The Undo button:</strong> &quot;undo&quot; reverses your most recent action first
+              </Typography>
+              <Typography variant="body2">
+                <strong>🌐 Browser back button:</strong> returns you to the page you visited most recently
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Try It Yourself">
+          <Typography variant="body2" paragraph>
+            Use <strong>Push</strong> to add a plate to the top and <strong>Pop</strong> to take the top plate off. Watch how everything happens at the top — the bottom plates never move.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="ds-controls">
+              <TextField
+                label="Value (optional)"
+                size="small"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') push(); }}
+                sx={{ width: 160 }}
+              />
+              <Button variant="contained" onClick={push}>Push</Button>
+              <Button variant="outlined" onClick={pop}>Pop</Button>
+              <Button variant="outlined" onClick={peek}>Peek</Button>
+            </div>
+
+            <div className="stack-area">
+              {displayItems.length === 0 && (
+                <div className="stack-empty">The stack is empty — push something on!</div>
+              )}
+              <div className="stack-column">
+                <AnimatePresence initial={false}>
+                  {displayItems.map((item, idx) => (
+                    <motion.div
+                      key={item.id}
+                      className={`stack-item ${idx === 0 ? 'top' : ''}`}
+                      layout
+                      initial={{ opacity: 0, y: -30 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -30 }}
+                      transition={{ duration: 0.25 }}
+                    >
+                      {item.value}
+                      {idx === 0 && <span className="stack-top-tag">← TOP</span>}
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+              <div className="stack-base" />
+            </div>
+            <p className="ds-caption">The dark bar is the bottom of the stack. New plates land on top.</p>
+
+            {message && <p className="ds-output">{message}</p>}
+          </div>
+        </Section>
+
+        <Section title="The Core Operations">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Typography variant="body2">
+                <strong>push(item)</strong> — add an item to the top of the stack
+              </Typography>
+              <Typography variant="body2">
+                <strong>pop()</strong> — remove and return the top item
+              </Typography>
+              <Typography variant="body2">
+                <strong>peek()</strong> — look at the top item without removing it
+              </Typography>
+              <Typography variant="body2">
+                <strong>is_empty()</strong> — check whether there is anything left
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Because every operation happens at one end, push and pop are extremely fast — they take the same tiny amount of time no matter how tall the stack gets. (That&apos;s <strong>O(1)</strong>, which you can read about in Algorithm Analysis &amp; Design.)
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Where Stacks Show Up">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Function calls:</strong> the computer uses a &quot;call stack&quot; to remember where to return after each function finishes
+              </Typography>
+              <Typography variant="body2">
+                <strong>Undo / redo:</strong> editors stack up your actions so the most recent can be reversed first
+              </Typography>
+              <Typography variant="body2">
+                <strong>Matching brackets:</strong> compilers use a stack to check that every <code>(</code> has a matching <code>)</code>
+              </Typography>
+              <Typography variant="body2">
+                <strong>Back navigation:</strong> your browser history behaves like a stack of pages
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/TreeConcept.tsx
+++ b/components/pageComponents/Python/TreeConcept.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import ConceptInfoCard from '../../common/ConceptInfoCard';
+import TableOfContents from '@/components/common/TableOfContents';
+import '../../../styles/dataStructures.css';
+
+type TreeNode = { value: number; left: TreeNode | null; right: TreeNode | null };
+type TraversalType = 'in' | 'pre' | 'post';
+
+function insert(node: TreeNode | null, value: number): TreeNode {
+  if (!node) return { value, left: null, right: null };
+  if (value < node.value) return { ...node, left: insert(node.left, value) };
+  if (value > node.value) return { ...node, right: insert(node.right, value) };
+  return node; // ignore duplicates
+}
+
+function traverse(node: TreeNode | null, type: TraversalType, acc: number[] = []): number[] {
+  if (!node) return acc;
+  if (type === 'pre') acc.push(node.value);
+  traverse(node.left, type, acc);
+  if (type === 'in') acc.push(node.value);
+  traverse(node.right, type, acc);
+  if (type === 'post') acc.push(node.value);
+  return acc;
+}
+
+const X_GAP = 58;
+const Y_GAP = 74;
+const R = 21;
+const PAD = 28;
+
+type Pos = { value: number; x: number; y: number };
+type Edge = { x1: number; y1: number; x2: number; y2: number };
+
+function computeLayout(root: TreeNode | null) {
+  const nodes: Pos[] = [];
+  const edges: Edge[] = [];
+  let idx = 0;
+  function walk(node: TreeNode | null, depth: number): Pos | null {
+    if (!node) return null;
+    const leftPos = walk(node.left, depth + 1);
+    const x = PAD + R + idx * X_GAP;
+    const y = PAD + R + depth * Y_GAP;
+    idx += 1;
+    const myPos: Pos = { value: node.value, x, y };
+    nodes.push(myPos);
+    const rightPos = walk(node.right, depth + 1);
+    if (leftPos) edges.push({ x1: x, y1: y, x2: leftPos.x, y2: leftPos.y });
+    if (rightPos) edges.push({ x1: x, y1: y, x2: rightPos.x, y2: rightPos.y });
+    return myPos;
+  }
+  walk(root, 0);
+  const width = nodes.reduce((m, n) => Math.max(m, n.x), 0) + R + PAD;
+  const height = nodes.reduce((m, n) => Math.max(m, n.y), 0) + R + PAD;
+  return { nodes, edges, width, height };
+}
+
+const initialTree = [50, 30, 70, 20, 40, 60, 80].reduce<TreeNode | null>(
+  (t, v) => insert(t, v),
+  null,
+);
+
+export default function TreeConcept() {
+  const [tree, setTree] = useState<TreeNode | null>(initialTree);
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Traversal animation state
+  const [order, setOrder] = useState<number[]>([]);
+  const [step, setStep] = useState(-1);
+  const [traversalName, setTraversalName] = useState('');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { nodes, edges, width, height } = useMemo(() => computeLayout(tree), [tree]);
+
+  const stopAnimation = () => {
+    if (timer.current) clearTimeout(timer.current);
+    setOrder([]);
+    setStep(-1);
+    setTraversalName('');
+  };
+
+  const addValue = (raw: string) => {
+    const v = parseInt(raw, 10);
+    if (isNaN(v)) {
+      setMessage('Please enter a whole number to insert.');
+      return;
+    }
+    stopAnimation();
+    setTree((t) => insert(t, v));
+    setMessage(`insert(${v}) — walked down from the root, going left for smaller and right for larger, until an empty spot was found.`);
+    setInput('');
+  };
+
+  const addRandom = () => {
+    const v = Math.floor(Math.random() * 99) + 1;
+    addValue(String(v));
+  };
+
+  const reset = () => {
+    stopAnimation();
+    setTree(initialTree);
+    setMessage(null);
+  };
+
+  const startTraversal = (type: TraversalType, name: string) => {
+    if (timer.current) clearTimeout(timer.current);
+    const seq = traverse(tree, type);
+    setTraversalName(name);
+    setOrder(seq);
+    setStep(0);
+  };
+
+  // Step the traversal highlight forward
+  useEffect(() => {
+    if (step < 0 || order.length === 0 || step >= order.length) return;
+    timer.current = setTimeout(() => setStep((s) => s + 1), 750);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [step, order]);
+
+  // Clean up on unmount
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const activeValue = step >= 0 && step < order.length ? order[step] : null;
+  const visited = order.slice(0, Math.min(step + 1, order.length));
+
+  return (
+    <ConceptWrapper
+      title="Trees"
+      description="A tree is a branching structure of connected nodes — like a family tree or a set of nested folders."
+    >
+      <TableOfContents numbered>
+        <Section title="Picture a Family Tree">
+          <Typography variant="body2" paragraph>
+            A tree organizes data into a <strong>hierarchy</strong>. There&apos;s one node at the very top called the <strong>root</strong>, and every node can branch into <strong>children</strong> below it. It looks just like a <em>family tree</em> drawn upside down, or the way <em>folders</em> nest inside folders on your computer.
+          </Typography>
+
+          <ConceptInfoCard>
+            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
+              Tree Vocabulary
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>🌳 Root:</strong> the single node at the top with no parent
+              </Typography>
+              <Typography variant="body2">
+                <strong>👶 Child / Parent:</strong> a node directly below / above another
+              </Typography>
+              <Typography variant="body2">
+                <strong>🍃 Leaf:</strong> a node with no children (the tips of the branches)
+              </Typography>
+              <Typography variant="body2">
+                <strong>📏 Depth:</strong> how many steps a node is from the root
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              The example below is a <strong>Binary Search Tree</strong>: each node has at most two children, and everything on the <em>left</em> is smaller while everything on the <em>right</em> is larger. That ordering makes searching very fast.
+            </Typography>
+          </Alert>
+        </Section>
+
+        <Section title="Build & Explore a Tree">
+          <Typography variant="body2" paragraph>
+            Insert numbers and watch where they land — smaller values branch left, larger values branch right. Then run a <strong>traversal</strong> to light up the nodes in the order a program would visit them.
+          </Typography>
+
+          <div className="ds-viz">
+            <div className="ds-controls">
+              <TextField
+                label="Number to insert"
+                size="small"
+                type="number"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') addValue(input); }}
+                sx={{ width: 150 }}
+              />
+              <Button variant="contained" onClick={() => addValue(input)}>Insert</Button>
+              <Button variant="outlined" onClick={addRandom}>Insert random</Button>
+              <Button variant="outlined" color="secondary" onClick={reset}>Reset</Button>
+            </div>
+
+            <div className="ds-controls" style={{ marginBottom: 8 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600, color: '#475569' }}>
+                Animate traversal:
+              </Typography>
+              <Button size="small" variant="outlined" onClick={() => startTraversal('in', 'In-order')}>In-order</Button>
+              <Button size="small" variant="outlined" onClick={() => startTraversal('pre', 'Pre-order')}>Pre-order</Button>
+              <Button size="small" variant="outlined" onClick={() => startTraversal('post', 'Post-order')}>Post-order</Button>
+              {order.length > 0 && (
+                <Button size="small" variant="text" color="secondary" onClick={stopAnimation}>Clear</Button>
+              )}
+            </div>
+
+            <div style={{ overflowX: 'auto' }}>
+              {nodes.length === 0 ? (
+                <Typography variant="body2" sx={{ color: '#94a3b8', fontStyle: 'italic', py: 4 }}>
+                  The tree is empty — insert a number to create the root.
+                </Typography>
+              ) : (
+                <svg
+                  width={Math.max(width, 320)}
+                  height={height}
+                  style={{ display: 'block', maxWidth: '100%' }}
+                  viewBox={`0 0 ${Math.max(width, 320)} ${height}`}
+                >
+                  {edges.map((e, i) => (
+                    <line
+                      key={`e-${i}`}
+                      x1={e.x1}
+                      y1={e.y1}
+                      x2={e.x2}
+                      y2={e.y2}
+                      stroke="#cbd5e1"
+                      strokeWidth={2}
+                    />
+                  ))}
+                  {nodes.map((n) => {
+                    const isActive = activeValue === n.value;
+                    const wasVisited = visited.includes(n.value) && !isActive;
+                    let fill = '#dbeafe';
+                    let stroke = '#2563eb';
+                    if (isActive) { fill = '#fde68a'; stroke = '#f59e0b'; }
+                    else if (wasVisited) { fill = '#bbf7d0'; stroke = '#22c55e'; }
+                    return (
+                      <g key={`n-${n.value}`}>
+                        <circle cx={n.x} cy={n.y} r={R} fill={fill} stroke={stroke} strokeWidth={2} />
+                        <text
+                          x={n.x}
+                          y={n.y}
+                          textAnchor="middle"
+                          dominantBaseline="central"
+                          fontSize={14}
+                          fontWeight={600}
+                          fill="#1e293b"
+                        >
+                          {n.value}
+                        </text>
+                      </g>
+                    );
+                  })}
+                </svg>
+              )}
+            </div>
+
+            {order.length > 0 && (
+              <p className="ds-output">
+                <strong>{traversalName}:</strong> {visited.join(' → ')}
+                {step >= order.length ? ' ✓' : ' …'}
+              </p>
+            )}
+            {message && order.length === 0 && <p className="ds-output">{message}</p>}
+
+            <div className="ds-legend">
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#dbeafe', borderColor: '#2563eb' }} /> Node</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#fde68a', borderColor: '#f59e0b' }} /> Visiting now</span>
+              <span className="ds-legend-item"><span className="ds-swatch" style={{ background: '#bbf7d0', borderColor: '#22c55e' }} /> Already visited</span>
+            </div>
+          </div>
+        </Section>
+
+        <Section title="Why In-order Gives Sorted Output">
+          <Typography variant="body2" paragraph>
+            Try the <strong>In-order</strong> traversal on a Binary Search Tree and watch the numbers come out in sorted order. That&apos;s no coincidence: in-order always visits <em>everything smaller</em> (the left side) before a node, then the node, then <em>everything larger</em> (the right side).
+          </Typography>
+
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>In-order (Left → Node → Right):</strong> visits values in sorted order
+              </Typography>
+              <Typography variant="body2">
+                <strong>Pre-order (Node → Left → Right):</strong> handy for copying or saving a tree
+              </Typography>
+              <Typography variant="body2">
+                <strong>Post-order (Left → Right → Node):</strong> handy for deleting a tree safely from the bottom up
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+
+        <Section title="Where Trees Show Up">
+          <ConceptInfoCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>File systems:</strong> folders containing folders containing files
+              </Typography>
+              <Typography variant="body2">
+                <strong>The HTML DOM:</strong> a web page is a tree of nested elements
+              </Typography>
+              <Typography variant="body2">
+                <strong>Search & databases:</strong> balanced trees keep lookups fast even with millions of records
+              </Typography>
+              <Typography variant="body2">
+                <strong>Decision making:</strong> game AI and flowcharts branch like trees
+              </Typography>
+            </Box>
+          </ConceptInfoCard>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/Python/TreeConcept.tsx
+++ b/components/pageComponents/Python/TreeConcept.tsx
@@ -2,14 +2,13 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import Alert from '@mui/material/Alert';
 import ConceptWrapper from '../../common/ConceptWrapper';
 import Section from '../../common/Section';
-import ConceptInfoCard from '../../common/ConceptInfoCard';
+import CalloutBox from '../../common/CalloutBox';
 import TableOfContents from '@/components/common/TableOfContents';
+import Box from '@mui/material/Box';
 import '../../../styles/dataStructures.css';
 
 type TreeNode = { value: number; left: TreeNode | null; right: TreeNode | null };
@@ -96,7 +95,7 @@ export default function TreeConcept() {
     }
     stopAnimation();
     setTree((t) => insert(t, v));
-    setMessage(`insert(${v}) — walked down from the root, going left for smaller and right for larger, until an empty spot was found.`);
+    setMessage(`insert(${v}) — starting at the root, the value goes left when smaller and right when larger until it finds an empty spot.`);
     setInput('');
   };
 
@@ -139,44 +138,35 @@ export default function TreeConcept() {
   return (
     <ConceptWrapper
       title="Trees"
-      description="A tree is a branching structure of connected nodes — like a family tree or a set of nested folders."
+      description="A tree is a branching structure of connected nodes, similar to a family tree or a set of nested folders."
     >
       <TableOfContents numbered>
-        <Section title="Picture a Family Tree">
+        {/* 1 ----------------------------------------------------------------- */}
+        <Section title="The Big Idea">
           <Typography variant="body2" paragraph>
-            A tree organizes data into a <strong>hierarchy</strong>. There&apos;s one node at the very top called the <strong>root</strong>, and every node can branch into <strong>children</strong> below it. It looks just like a <em>family tree</em> drawn upside down, or the way <em>folders</em> nest inside folders on your computer.
+            A tree organizes data into a <strong>hierarchy</strong>. A single node at the top, called the <strong>root</strong>, branches into <strong>children</strong> below it, and each child can branch further. The shape mirrors a family tree drawn upside down, or the way folders nest inside folders on a computer.
           </Typography>
 
-          <ConceptInfoCard>
-            <Typography variant="subtitle1" gutterBottom fontWeight="medium">
-              Tree Vocabulary
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>🌳 Root:</strong> the single node at the top with no parent
-              </Typography>
-              <Typography variant="body2">
-                <strong>👶 Child / Parent:</strong> a node directly below / above another
-              </Typography>
-              <Typography variant="body2">
-                <strong>🍃 Leaf:</strong> a node with no children (the tips of the branches)
-              </Typography>
-              <Typography variant="body2">
-                <strong>📏 Depth:</strong> how many steps a node is from the root
-              </Typography>
+          <CalloutBox title="Tree vocabulary" type="info">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>Root:</strong> the single node at the top, with no parent.</Typography>
+              <Typography variant="body2"><strong>Child / Parent:</strong> a node directly below / above another.</Typography>
+              <Typography variant="body2"><strong>Leaf:</strong> a node with no children (the tips of the branches).</Typography>
+              <Typography variant="body2"><strong>Depth:</strong> the number of steps from the root to a node.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
 
-          <Alert severity="info" sx={{ mt: 2 }}>
+          <CalloutBox title="This example is a Binary Search Tree" type="key-concepts">
             <Typography variant="body2">
-              The example below is a <strong>Binary Search Tree</strong>: each node has at most two children, and everything on the <em>left</em> is smaller while everything on the <em>right</em> is larger. That ordering makes searching very fast.
+              Each node has at most two children, and everything in the <em>left</em> branch is smaller while everything in the <em>right</em> branch is larger. This ordering is what makes searching a tree fast.
             </Typography>
-          </Alert>
+          </CalloutBox>
         </Section>
 
-        <Section title="Build & Explore a Tree">
+        {/* 2 ----------------------------------------------------------------- */}
+        <Section title="Build and Explore a Tree">
           <Typography variant="body2" paragraph>
-            Insert numbers and watch where they land — smaller values branch left, larger values branch right. Then run a <strong>traversal</strong> to light up the nodes in the order a program would visit them.
+            Insert numbers and observe where each one lands — smaller values branch left, larger values branch right. Then run a <strong>traversal</strong> to highlight the nodes in the order a program would visit them.
           </Typography>
 
           <div className="ds-viz">
@@ -220,15 +210,7 @@ export default function TreeConcept() {
                   viewBox={`0 0 ${Math.max(width, 320)} ${height}`}
                 >
                   {edges.map((e, i) => (
-                    <line
-                      key={`e-${i}`}
-                      x1={e.x1}
-                      y1={e.y1}
-                      x2={e.x2}
-                      y2={e.y2}
-                      stroke="#cbd5e1"
-                      strokeWidth={2}
-                    />
+                    <line key={`e-${i}`} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2} stroke="#cbd5e1" strokeWidth={2} />
                   ))}
                   {nodes.map((n) => {
                     const isActive = activeValue === n.value;
@@ -240,15 +222,7 @@ export default function TreeConcept() {
                     return (
                       <g key={`n-${n.value}`}>
                         <circle cx={n.x} cy={n.y} r={R} fill={fill} stroke={stroke} strokeWidth={2} />
-                        <text
-                          x={n.x}
-                          y={n.y}
-                          textAnchor="middle"
-                          dominantBaseline="central"
-                          fontSize={14}
-                          fontWeight={600}
-                          fill="#1e293b"
-                        >
+                        <text x={n.x} y={n.y} textAnchor="middle" dominantBaseline="central" fontSize={14} fontWeight={600} fill="#1e293b">
                           {n.value}
                         </text>
                       </g>
@@ -261,7 +235,7 @@ export default function TreeConcept() {
             {order.length > 0 && (
               <p className="ds-output">
                 <strong>{traversalName}:</strong> {visited.join(' → ')}
-                {step >= order.length ? ' ✓' : ' …'}
+                {step >= order.length ? ' (complete)' : ' …'}
               </p>
             )}
             {message && order.length === 0 && <p className="ds-output">{message}</p>}
@@ -274,43 +248,42 @@ export default function TreeConcept() {
           </div>
         </Section>
 
-        <Section title="Why In-order Gives Sorted Output">
+        {/* 3 ----------------------------------------------------------------- */}
+        <Section title="Why In-order Produces Sorted Output">
           <Typography variant="body2" paragraph>
-            Try the <strong>In-order</strong> traversal on a Binary Search Tree and watch the numbers come out in sorted order. That&apos;s no coincidence: in-order always visits <em>everything smaller</em> (the left side) before a node, then the node, then <em>everything larger</em> (the right side).
+            Run the <strong>in-order</strong> traversal on the Binary Search Tree and the numbers emerge in sorted order. This is not a coincidence: in-order always visits everything smaller (the left branch) before a node, then the node, then everything larger (the right branch).
           </Typography>
 
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>In-order (Left → Node → Right):</strong> visits values in sorted order
-              </Typography>
-              <Typography variant="body2">
-                <strong>Pre-order (Node → Left → Right):</strong> handy for copying or saving a tree
-              </Typography>
-              <Typography variant="body2">
-                <strong>Post-order (Left → Right → Node):</strong> handy for deleting a tree safely from the bottom up
-              </Typography>
+          <CalloutBox title="The three traversal orders" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>In-order (Left, Node, Right):</strong> visits values in sorted order.</Typography>
+              <Typography variant="body2"><strong>Pre-order (Node, Left, Right):</strong> useful for copying or saving a tree.</Typography>
+              <Typography variant="body2"><strong>Post-order (Left, Right, Node):</strong> useful for deleting a tree safely from the bottom up.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
         </Section>
 
-        <Section title="Where Trees Show Up">
-          <ConceptInfoCard>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>File systems:</strong> folders containing folders containing files
-              </Typography>
-              <Typography variant="body2">
-                <strong>The HTML DOM:</strong> a web page is a tree of nested elements
-              </Typography>
-              <Typography variant="body2">
-                <strong>Search & databases:</strong> balanced trees keep lookups fast even with millions of records
-              </Typography>
-              <Typography variant="body2">
-                <strong>Decision making:</strong> game AI and flowcharts branch like trees
-              </Typography>
+        {/* 4 ----------------------------------------------------------------- */}
+        <Section title="Where Trees Are Used">
+          <CalloutBox title="Common applications" type="key-concepts">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>File systems:</strong> folders containing folders containing files.</Typography>
+              <Typography variant="body2"><strong>The HTML DOM:</strong> a web page is a tree of nested elements.</Typography>
+              <Typography variant="body2"><strong>Search and databases:</strong> balanced trees keep lookups fast even with millions of records.</Typography>
+              <Typography variant="body2"><strong>Decision making:</strong> game AI and flowcharts branch like trees.</Typography>
             </Box>
-          </ConceptInfoCard>
+          </CalloutBox>
+        </Section>
+
+        {/* 5 ----------------------------------------------------------------- */}
+        <Section title="Key Takeaways">
+          <CalloutBox title="Summary" type="success">
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mt: 1 }}>
+              <Typography variant="body2"><strong>A tree is a hierarchy</strong> of nodes branching from a single root.</Typography>
+              <Typography variant="body2"><strong>A Binary Search Tree</strong> keeps smaller values left and larger values right, making lookups fast.</Typography>
+              <Typography variant="body2"><strong>Traversals</strong> visit nodes in a defined order; in-order yields sorted output.</Typography>
+            </Box>
+          </CalloutBox>
         </Section>
       </TableOfContents>
     </ConceptWrapper>

--- a/styles/dataStructures.css
+++ b/styles/dataStructures.css
@@ -355,3 +355,164 @@
   color: #475569;
   flex-shrink: 0;
 }
+
+/* ===========================================================================
+   Static illustration helpers (used to make concepts more visual)
+   =========================================================================== */
+.illus {
+  margin: 16px 0;
+}
+
+.illus-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: #475569;
+  margin-bottom: 8px;
+}
+
+.illus-cells {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.illus-cell {
+  position: relative;
+  min-width: 46px;
+  height: 46px;
+  padding: 0 6px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 15px;
+  color: #1e293b;
+}
+
+.illus-cell.dim {
+  opacity: 0.35;
+}
+
+.illus-cell.hit {
+  background: #fef9c3;
+  border-color: #facc15;
+}
+
+.illus-cell.target {
+  background: #bbf7d0;
+  border-color: #22c55e;
+}
+
+.viz-badge {
+  position: absolute;
+  top: -10px;
+  left: -8px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 4px;
+  border-radius: 10px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.viz-badge.binary {
+  background: #8b5cf6;
+}
+
+/* Halving diagram (binary search "wow" visual) */
+.halve-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.halve-bar {
+  height: 28px;
+  border-radius: 6px;
+  background: #a5b4fc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1e1b4b;
+  font-size: 12px;
+  font-weight: 700;
+  min-width: 28px;
+}
+
+.halve-note {
+  font-size: 13px;
+  color: #475569;
+}
+
+/* Horizontal "flow" of steps (recipe / pipeline) */
+.flow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.flow-step {
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #3730a3;
+  text-align: center;
+}
+
+.flow-arrow {
+  font-size: 22px;
+  color: #94a3b8;
+}
+
+/* Two-card compare/swap visual (sorting) */
+.cards-compare {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.play-card {
+  width: 64px;
+  height: 88px;
+  border-radius: 10px;
+  border: 2px solid #cbd5e1;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  font-weight: 700;
+  color: #1e293b;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.play-card.big {
+  border-color: #f87171;
+  background: #fef2f2;
+}
+
+.compare-symbol {
+  font-size: 26px;
+  font-weight: 700;
+  color: #ef4444;
+}
+
+.swap-arrows {
+  font-size: 26px;
+  color: #2563eb;
+}

--- a/styles/dataStructures.css
+++ b/styles/dataStructures.css
@@ -516,3 +516,133 @@
   font-size: 26px;
   color: #2563eb;
 }
+
+/* ===========================================================================
+   OOP interactive widgets
+   =========================================================================== */
+.obj-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.obj-card {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 14px 16px;
+  min-width: 190px;
+}
+
+.obj-card-title {
+  font-family: monospace;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.obj-attr {
+  font-family: monospace;
+  font-size: 13px;
+  color: #475569;
+  margin: 2px 0;
+}
+
+.obj-attr .obj-key {
+  color: #2563eb;
+}
+
+/* Console-style output panel for method results */
+.output-panel {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-family: monospace;
+  font-size: 13px;
+  min-height: 46px;
+  white-space: pre-wrap;
+  line-height: 1.65;
+  margin-top: 12px;
+}
+
+.output-panel .muted {
+  color: #64748b;
+}
+
+.output-panel .ok {
+  color: #4ade80;
+}
+
+.output-panel .err {
+  color: #f87171;
+}
+
+.output-panel .out-prompt {
+  color: #38bdf8;
+  user-select: none;
+}
+
+/* Shape row for polymorphism */
+.shape-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.shape-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 14px;
+  text-align: center;
+  min-width: 150px;
+}
+
+.shape-card svg {
+  display: block;
+  margin: 0 auto 8px;
+}
+
+/* Selectable option chips (e.g. payment methods, subclasses) */
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.select-chip {
+  border: 1.5px solid #cbd5e1;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.select-chip:hover {
+  border-color: #94a3b8;
+}
+
+.select-chip.selected {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+/* Neutral avatar used in the queue (replaces emoji) */
+.queue-avatar {
+  display: block;
+  width: 26px;
+  height: 26px;
+  margin: 0 auto 4px;
+  border-radius: 50%;
+  background: #86efac;
+  border: 1px solid #16a34a;
+}

--- a/styles/dataStructures.css
+++ b/styles/dataStructures.css
@@ -1,0 +1,357 @@
+/* ===========================================================================
+   Shared visualization styles for Data Structures & Algorithms concept pages.
+   Modeled on the array visualizer (see array.css) but extended for stacks,
+   queues, trees, recursion, searching and sorting.
+   =========================================================================== */
+
+.ds-viz {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin: 16px 0 24px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+}
+
+.ds-controls {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.ds-output {
+  font-size: 15px;
+  font-weight: 500;
+  color: #334155;
+  min-height: 22px;
+  margin-top: 10px;
+}
+
+.ds-caption {
+  font-size: 13px;
+  color: #64748b;
+  font-style: italic;
+  text-align: center;
+  margin-top: 6px;
+}
+
+.ds-legend {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: #475569;
+  margin-top: 16px;
+}
+
+.ds-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ds-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  display: inline-block;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* --------------------------------- Stack --------------------------------- */
+.stack-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 340px;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.stack-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.stack-item {
+  position: relative;
+  width: 190px;
+  padding: 16px 0;
+  text-align: center;
+  border-radius: 10px;
+  background: #dbeafe;
+  border: 1px solid #60a5fa;
+  font-weight: 600;
+  font-size: 18px;
+  color: #1e3a8a;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.08);
+}
+
+.stack-item.top {
+  background: #bfdbfe;
+  border-color: #2563eb;
+}
+
+.stack-top-tag {
+  position: absolute;
+  right: -78px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  font-weight: 700;
+  color: #2563eb;
+  white-space: nowrap;
+}
+
+.stack-base {
+  width: 230px;
+  height: 16px;
+  background: #475569;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.stack-empty {
+  color: #94a3b8;
+  font-style: italic;
+  padding: 24px 0;
+}
+
+/* --------------------------------- Queue --------------------------------- */
+.queue-area {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 28px 4px 8px;
+  min-height: 120px;
+}
+
+.queue-item {
+  min-width: 72px;
+  padding: 16px 14px;
+  border-radius: 10px;
+  background: #dcfce7;
+  border: 1px solid #4ade80;
+  font-weight: 600;
+  font-size: 18px;
+  color: #14532d;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+}
+
+.queue-item .queue-emoji {
+  display: block;
+  font-size: 20px;
+  margin-bottom: 2px;
+}
+
+.queue-tag {
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.queue-tag.front {
+  color: #16a34a;
+}
+
+.queue-tag.back {
+  color: #2563eb;
+}
+
+.queue-empty {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+/* --------------------------- Searching cells ----------------------------- */
+.cells-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 16px 0;
+}
+
+.search-cell {
+  min-width: 60px;
+  min-height: 64px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.25s, border-color 0.25s, transform 0.2s;
+}
+
+.search-cell .cell-index {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-bottom: 2px;
+}
+
+.search-cell .cell-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.search-cell.range {
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.search-cell.active {
+  background: #fef9c3;
+  border-color: #facc15;
+  transform: translateY(-4px);
+}
+
+.search-cell.eliminated {
+  opacity: 0.35;
+}
+
+.search-cell.found {
+  background: #bbf7d0;
+  border-color: #22c55e;
+  transform: translateY(-4px);
+}
+
+/* --------------------------- Sorting bars -------------------------------- */
+.bars-area {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 240px;
+  padding-top: 10px;
+}
+
+.bar {
+  flex: 1;
+  min-width: 14px;
+  background: #93c5fd;
+  border-radius: 5px 5px 0 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  color: #1e3a8a;
+  font-size: 12px;
+  font-weight: 600;
+  padding-bottom: 4px;
+  transition: height 0.25s ease, background 0.2s ease;
+}
+
+.bar.compare {
+  background: #fbbf24;
+}
+
+.bar.swap {
+  background: #f87171;
+}
+
+.bar.sorted {
+  background: #34d399;
+  color: #064e3b;
+}
+
+/* --------------------------- Recursion frames ---------------------------- */
+.rec-frames {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.rec-frame {
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  font-family: monospace;
+  font-size: 15px;
+  color: #334155;
+  transition: background 0.2s, border-color 0.2s, opacity 0.2s;
+}
+
+.rec-frame.calling {
+  background: #fef9c3;
+  border-color: #facc15;
+}
+
+.rec-frame.active {
+  background: #fde68a;
+  border-color: #f59e0b;
+  font-weight: 700;
+}
+
+.rec-frame.base {
+  background: #fee2e2;
+  border-color: #f87171;
+}
+
+.rec-frame.returning {
+  background: #dcfce7;
+  border-color: #4ade80;
+}
+
+.rec-frame .rec-return {
+  color: #15803d;
+  font-weight: 700;
+}
+
+/* ------------------------- Big-O growth bars ----------------------------- */
+.bigo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.bigo-label {
+  width: 130px;
+  font-family: monospace;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
+  flex-shrink: 0;
+}
+
+.bigo-track {
+  flex: 1;
+  background: #f1f5f9;
+  border-radius: 6px;
+  overflow: hidden;
+  height: 26px;
+}
+
+.bigo-fill {
+  height: 100%;
+  border-radius: 6px;
+  transition: width 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.bigo-steps {
+  width: 120px;
+  font-size: 13px;
+  color: #475569;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Add a new "Object-Oriented Programming" section to the Python page side nav with six concept pages: Classes & Objects, Attributes & Methods, Inheritance, Encapsulation, Polymorphism, and Abstraction.

Each page follows the existing concept conventions (ConceptWrapper, numbered TableOfContents, Section, ConceptInfoCard, CodePartsExplanation, StepThroughCodeAnimation, CodeSnippet) and progresses from foundations to the four pillars of OOP.