### PR TITLE
feat: interactive Version Control topic (committing, branching, pushing)

### DIFF
--- a/components/landing/conceptIndex.ts
+++ b/components/landing/conceptIndex.ts
@@ -21,6 +21,7 @@ import {
   softwareTestingNavItems,
   websiteManagementNavItems,
   projectManagementNavItems,
+  versionControlNavItems,
 } from '@/components/pageComponents/navItems';
 
 export interface ConceptEntry {
@@ -49,6 +50,7 @@ const navByTopic: Record<string, SidebarItem[]> = {
   'software-testing': softwareTestingNavItems,
   'website-management': websiteManagementNavItems,
   'project-management': projectManagementNavItems,
+  'version-control': versionControlNavItems,
 };
 
 /** Collect the leaf nodes (actual concept pages) from a nav tree. */

--- a/components/landing/topics.ts
+++ b/components/landing/topics.ts
@@ -42,6 +42,7 @@ export const topicNodes: TopicNode[] = [
   { id: 'software-testing', label: 'Software Testing', type: 'Topic', route: '/skills/software-testing', category: 'process' },
   { id: 'website-management', label: 'Website Management', type: 'Topic', route: '/skills/website-management', category: 'web' },
   { id: 'project-management', label: 'Project Management', type: 'Topic', route: '/skills/project-management', category: 'process' },
+  { id: 'version-control', label: 'Version Control', type: 'Topic', route: '/skills/version-control', category: 'process' },
 ];
 
 export const topicLinks: TopicLink[] = [
@@ -60,6 +61,9 @@ export const topicLinks: TopicLink[] = [
   { source: 'project-management', target: 'website-management' },
   { source: 'project-management', target: 'software-testing' },
   { source: 'project-management', target: 'python' },
+  { source: 'version-control', target: 'project-management' },
+  { source: 'version-control', target: 'software-testing' },
+  { source: 'version-control', target: 'website-management' },
 ];
 
 /**

--- a/components/pageComponents/VersionControl/BranchingConcept.constants.ts
+++ b/components/pageComponents/VersionControl/BranchingConcept.constants.ts
@@ -1,0 +1,31 @@
+export interface BranchCommit {
+  id: number;
+  hash: string;
+  message: string;
+}
+
+export interface Branch {
+  name: string;
+  commits: BranchCommit[];
+  color: string;
+}
+
+export const MAIN_BRANCH: Branch = {
+  name: 'main',
+  commits: [
+    { id: 1, hash: 'A1B2C3', message: 'Initial commit' },
+    { id: 2, hash: 'D4E5F6', message: 'Add database' },
+    { id: 3, hash: 'G7H8I9', message: 'Update API' },
+  ],
+  color: 'var(--info)',
+};
+
+export const FEATURE_BRANCH: Branch = {
+  name: 'feature/dark-mode',
+  commits: [
+    { id: 3, hash: 'G7H8I9', message: 'Update API' },
+    { id: 4, hash: 'J1K2L3', message: 'Add dark mode toggle' },
+    { id: 5, hash: 'M4N5O6', message: 'Style dark theme' },
+  ],
+  color: 'var(--feature)',
+};

--- a/components/pageComponents/VersionControl/BranchingConcept.tsx
+++ b/components/pageComponents/VersionControl/BranchingConcept.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import TableOfContents from '@/components/common/TableOfContents';
+import BranchGraph from './SubComponents/BranchGraph';
+
+export default function BranchingConcept() {
+  return (
+    <ConceptWrapper
+      title="Branching: Parallel Lines of Work"
+      description="Branches let you experiment and develop features in isolation, keeping the main code safe."
+    >
+      <TableOfContents>
+        <Section title="1. Why Branch?">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Typography sx={{ mb: 2 }}>
+              Imagine you're working on a large project with a team. You want to add a new feature (like a dark mode) but you're not ready to put it in the main product yet. You also don't want your half-finished code to break things for other developers.
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              This is where <b>branches</b> come in. A branch is a separate line of development that diverges from the main code. You can work on a branch without affecting the main branch, test your changes thoroughly, and only merge them back when you're confident they work.
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              Branches make it safe for multiple developers to work on different features at the same time.
+            </Typography>
+          </Box>
+        </Section>
+
+        <Section
+          title="2. Visualize Branches and Commits"
+          subtitle="Try it: switch between branches, make commits, and merge them back to main."
+        >
+          <BranchGraph />
+        </Section>
+
+        <Section title="3. Common Branching Patterns">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Box sx={{ mb: 3 }}>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--info)' }}>
+                Feature Branch
+              </Typography>
+              <Typography sx={{ color: 'var(--ink-soft)', mb: 2 }}>
+                Used to develop a single feature in isolation.
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                }}
+              >
+                git checkout -b feature/dark-mode
+              </Box>
+            </Box>
+
+            <Box sx={{ mb: 3 }}>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--success)' }}>
+                Bug Fix Branch
+              </Typography>
+              <Typography sx={{ color: 'var(--ink-soft)', mb: 2 }}>
+                Created to fix a specific bug in production.
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                }}
+              >
+                git checkout -b bugfix/login-issue
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--warning)' }}>
+                Release Branch
+              </Typography>
+              <Typography sx={{ color: 'var(--ink-soft)', mb: 2 }}>
+                Prepared for a release to production.
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                }}
+              >
+                git checkout -b release/v1.2.0
+              </Box>
+            </Box>
+          </Box>
+        </Section>
+
+        <Section title="4. Merging: Bringing It All Together">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Typography sx={{ mb: 2 }}>
+              When you're happy with the work on your branch, you <b>merge</b> it back into the main branch. This combines your commits with the main history so everyone can use your new feature or bug fix.
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              A typical merge workflow looks like this:
+            </Typography>
+            <Box sx={{ pl: 2, mb: 2 }}>
+              <Typography sx={{ mb: 1 }}>
+                1. <code>git checkout main</code> — switch to main
+              </Typography>
+              <Typography sx={{ mb: 1 }}>
+                2. <code>git pull</code> — get the latest changes from your team
+              </Typography>
+              <Typography sx={{ mb: 1 }}>
+                3. <code>git merge feature/dark-mode</code> — merge your branch into main
+              </Typography>
+              <Typography sx={{ mb: 1 }}>
+                4. <code>git push</code> — send your merged work to the remote
+              </Typography>
+            </Box>
+            <Typography sx={{ mb: 2 }}>
+              <b>Tip:</b> Before merging, make sure your branch is up to date with main (by pulling or rebasing). This prevents merge conflicts.
+            </Typography>
+          </Box>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/VersionControl/CommittingConcept.constants.ts
+++ b/components/pageComponents/VersionControl/CommittingConcept.constants.ts
@@ -1,0 +1,26 @@
+export interface ChangedFile {
+  id: string;
+  name: string;
+  status: 'modified' | 'new';
+}
+
+export const INITIAL_CHANGED_FILES: ChangedFile[] = [
+  { id: '1', name: 'app.js', status: 'modified' },
+  { id: '2', name: 'utils.js', status: 'modified' },
+  { id: '3', name: 'config.json', status: 'new' },
+];
+
+export interface Commit {
+  hash: string;
+  message: string;
+  timestamp: string;
+}
+
+export const generateCommitHash = (): string => {
+  return Math.random().toString(16).substring(2, 9).toUpperCase();
+};
+
+export const getCurrentTimestamp = (): string => {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+};

--- a/components/pageComponents/VersionControl/CommittingConcept.tsx
+++ b/components/pageComponents/VersionControl/CommittingConcept.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import TableOfContents from '@/components/common/TableOfContents';
+import CommitDemo from './SubComponents/CommitDemo';
+
+export default function CommittingConcept() {
+  return (
+    <ConceptWrapper
+      title="Making Commits: Saving Your Work"
+      description="A commit is a snapshot of your code at a point in time. Learn how to stage changes and create meaningful commit messages."
+    >
+      <TableOfContents>
+        <Section title="1. What Is a Commit?">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Typography sx={{ mb: 2 }}>
+              When you work on code, you make many small changes — fixing a bug, adding a feature, or refactoring a section. A <b>commit</b> is a snapshot that captures all those changes at one moment in time.
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              Think of commits like save points in a video game. After each one, you can always go back to a previous version if something breaks, or see exactly what changed between two points in history.
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              Each commit has two key parts:
+            </Typography>
+            <Box sx={{ pl: 2, mb: 2 }}>
+              <Typography sx={{ mb: 1 }}>
+                <b>The changes:</b> Which files changed and how.
+              </Typography>
+              <Typography sx={{ mb: 1 }}>
+                <b>The message:</b> A short description of <i>why</i> you made these changes, like "Fix login button styling" or "Add email validation."
+              </Typography>
+            </Box>
+          </Box>
+        </Section>
+
+        <Section
+          title="2. Make a Commit"
+          subtitle="Try it yourself: move files from your working directory to the staging area, write a message, and commit."
+        >
+          <CommitDemo />
+        </Section>
+
+        <Section title="3. Anatomy of a Good Commit Message">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Typography sx={{ mb: 2 }}>
+              A good commit message is short, clear, and describes <b>what changed and why</b>. Here are some examples:
+            </Typography>
+
+            <Box
+              sx={{
+                my: 3,
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                gap: 2,
+              }}
+            >
+              {/* Good example */}
+              <Box
+                sx={{
+                  p: 2,
+                  background: 'var(--success-bg)',
+                  border: '2px solid var(--success)',
+                  borderRadius: 1,
+                }}
+              >
+                <Typography sx={{ fontWeight: 700, color: 'var(--success)', mb: 1 }}>
+                  ✓ Good
+                </Typography>
+                <Box
+                  sx={{
+                    p: 1,
+                    background: 'var(--code-bg)',
+                    color: 'var(--code-fg)',
+                    borderRadius: 1,
+                    fontFamily: 'monospace',
+                    fontSize: '0.85rem',
+                    mb: 1,
+                  }}
+                >
+                  Fix login button styling on mobile
+                </Box>
+                <Typography sx={{ fontSize: '0.85rem', color: 'var(--ink-soft)' }}>
+                  Clear, specific, and actionable.
+                </Typography>
+              </Box>
+
+              {/* Bad example */}
+              <Box
+                sx={{
+                  p: 2,
+                  background: 'var(--danger-bg)',
+                  border: '2px solid var(--danger)',
+                  borderRadius: 1,
+                }}
+              >
+                <Typography sx={{ fontWeight: 700, color: 'var(--danger)', mb: 1 }}>
+                  ✗ Avoid
+                </Typography>
+                <Box
+                  sx={{
+                    p: 1,
+                    background: 'var(--code-bg)',
+                    color: 'var(--code-fg)',
+                    borderRadius: 1,
+                    fontFamily: 'monospace',
+                    fontSize: '0.85rem',
+                    mb: 1,
+                  }}
+                >
+                  updates
+                </Box>
+                <Typography sx={{ fontSize: '0.85rem', color: 'var(--ink-soft)' }}>
+                  Vague. Future you won't remember what this was.
+                </Typography>
+              </Box>
+            </Box>
+
+            <Typography sx={{ mb: 2, mt: 3 }}>
+              <b>Pro tip:</b> Use the present tense and imagine you're completing the sentence: "If applied, this commit will <i>[your message]</i>." For example: "If applied, this commit will <i>fix login button styling on mobile.</i>"
+            </Typography>
+          </Box>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/VersionControl/PushingConcept.constants.ts
+++ b/components/pageComponents/VersionControl/PushingConcept.constants.ts
@@ -1,0 +1,9 @@
+export interface Commit {
+  hash: string;
+  message: string;
+}
+
+export const INITIAL_COMMITS: Commit[] = [
+  { hash: 'A1B2C3', message: 'Initial project setup' },
+  { hash: 'D4E5F6', message: 'Add main features' },
+];

--- a/components/pageComponents/VersionControl/PushingConcept.tsx
+++ b/components/pageComponents/VersionControl/PushingConcept.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import ConceptWrapper from '../../common/ConceptWrapper';
+import Section from '../../common/Section';
+import TableOfContents from '@/components/common/TableOfContents';
+import PushDemo from './SubComponents/PushDemo';
+
+export default function PushingConcept() {
+  return (
+    <ConceptWrapper
+      title="Pushing: Syncing with the Remote"
+      description="Learn how to send your local commits to a remote repository so your team can see your work."
+    >
+      <TableOfContents>
+        <Section title="1. Local vs Remote">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Typography sx={{ mb: 2 }}>
+              When you work on a project, you have two repositories:
+            </Typography>
+            <Box sx={{ pl: 2, mb: 2 }}>
+              <Typography sx={{ mb: 1 }}>
+                <b>Local repository:</b> The copy of your code on your computer. All your commits live here.
+              </Typography>
+              <Typography sx={{ mb: 1 }}>
+                <b>Remote repository:</b> The central copy hosted on GitHub, GitLab, or another server. This is where your team collaborates and where the "official" version lives.
+              </Typography>
+            </Box>
+            <Typography sx={{ mb: 2 }}>
+              When you <b>push</b>, you upload your local commits to the remote so everyone else can see and use your work.
+            </Typography>
+          </Box>
+        </Section>
+
+        <Section
+          title="2. Try Pushing"
+          subtitle="Create local commits and push them to simulate syncing with GitHub."
+        >
+          <PushDemo />
+        </Section>
+
+        <Section title="3. Pull vs Push: A Quick Comparison">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                gap: 2,
+                mb: 2,
+              }}
+            >
+              {/* Push */}
+              <Box
+                sx={{
+                  p: 2,
+                  background: 'var(--feature-bg)',
+                  border: '2px solid var(--feature)',
+                  borderRadius: 1,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    color: 'var(--feature)',
+                    mb: 1,
+                  }}
+                >
+                  Push
+                </Typography>
+                <Typography sx={{ color: 'var(--ink-soft)', fontSize: '0.9rem' }}>
+                  Sends your local commits <b>up to</b> the remote. Share your work with the team.
+                </Typography>
+              </Box>
+
+              {/* Pull */}
+              <Box
+                sx={{
+                  p: 2,
+                  background: 'var(--info-bg)',
+                  border: '2px solid var(--info)',
+                  borderRadius: 1,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    color: 'var(--info)',
+                    mb: 1,
+                  }}
+                >
+                  Pull
+                </Typography>
+                <Typography sx={{ color: 'var(--ink-soft)', fontSize: '0.9rem' }}>
+                  Downloads commits <b>from</b> the remote. Catch up with your team's changes.
+                </Typography>
+              </Box>
+            </Box>
+
+            <Typography sx={{ mb: 2, mt: 3 }}>
+              <b>Workflow tip:</b> Always pull before pushing. This ensures your local branch has all the latest changes from your teammates, reducing conflicts.
+            </Typography>
+          </Box>
+        </Section>
+
+        <Section title="4. Common Push Scenarios">
+          <Box sx={{ maxWidth: 700, mx: 'auto', my: 3 }}>
+            <Box sx={{ mb: 3 }}>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--info)' }}>
+                Push a new feature branch
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                }}
+              >
+                git push origin feature/new-feature
+              </Box>
+            </Box>
+
+            <Box sx={{ mb: 3 }}>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--success)' }}>
+                Push to main after merging
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                }}
+              >
+                git push origin main
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography sx={{ fontWeight: 700, mb: 1, color: 'var(--warning)' }}>
+                Force push (use with caution!)
+              </Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  background: 'var(--code-bg)',
+                  color: 'var(--code-fg)',
+                  borderRadius: 1,
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                  mb: 1,
+                }}
+              >
+                git push origin --force
+              </Box>
+              <Typography
+                sx={{
+                  fontSize: '0.85rem',
+                  color: 'var(--danger)',
+                  fontStyle: 'italic',
+                }}
+              >
+                Only use force push if you know what you're doing. It can overwrite your team's work!
+              </Typography>
+            </Box>
+          </Box>
+        </Section>
+      </TableOfContents>
+    </ConceptWrapper>
+  );
+}

--- a/components/pageComponents/VersionControl/SubComponents/BranchGraph.tsx
+++ b/components/pageComponents/VersionControl/SubComponents/BranchGraph.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Box, Button, Typography, Paper, Stack, Chip } from '@mui/material';
+import {
+  MAIN_BRANCH,
+  FEATURE_BRANCH,
+  Branch,
+  BranchCommit,
+} from '../BranchingConcept.constants';
+
+export default function BranchGraph() {
+  const [currentBranch, setCurrentBranch] = useState<'main' | 'feature'>('main');
+  const [mainCommits, setMainCommits] = useState<BranchCommit[]>(MAIN_BRANCH.commits);
+  const [featureCommits, setFeatureCommits] = useState<BranchCommit[]>(
+    FEATURE_BRANCH.commits
+  );
+  const [isMerged, setIsMerged] = useState(false);
+
+  const addCommit = () => {
+    if (currentBranch === 'main') {
+      const lastId = Math.max(...mainCommits.map((c) => c.id));
+      const newCommit: BranchCommit = {
+        id: lastId + 1,
+        hash: Math.random().toString(16).substring(2, 8).toUpperCase(),
+        message: `Commit on main #${lastId + 1}`,
+      };
+      setMainCommits([...mainCommits, newCommit]);
+    } else {
+      const lastId = Math.max(...featureCommits.map((c) => c.id));
+      const newCommit: BranchCommit = {
+        id: lastId + 1,
+        hash: Math.random().toString(16).substring(2, 8).toUpperCase(),
+        message: `Commit on feature #${lastId + 1}`,
+      };
+      setFeatureCommits([...featureCommits, newCommit]);
+    }
+  };
+
+  const merge = () => {
+    setIsMerged(true);
+  };
+
+  const reset = () => {
+    setMainCommits(MAIN_BRANCH.commits);
+    setFeatureCommits(FEATURE_BRANCH.commits);
+    setIsMerged(false);
+    setCurrentBranch('main');
+  };
+
+  const renderCommit = (commit: BranchCommit, color: string) => (
+    <Box
+      key={commit.id}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          width: 48,
+          height: 48,
+          borderRadius: '50%',
+          background: color,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          fontWeight: 700,
+          fontSize: '0.85rem',
+          boxShadow: 2,
+        }}
+      >
+        {commit.id}
+      </Box>
+      <Typography
+        sx={{
+          mt: 1,
+          fontSize: '0.75rem',
+          textAlign: 'center',
+          color: 'var(--ink-faint)',
+          fontFamily: 'monospace',
+          maxWidth: 60,
+        }}
+      >
+        {commit.hash}
+      </Typography>
+    </Box>
+  );
+
+  const renderBranchLine = (commits: BranchCommit[], color: string) => (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+      {commits.map((commit, index) => (
+        <React.Fragment key={commit.id}>
+          {renderCommit(commit, color)}
+          {index < commits.length - 1 && (
+            <Box
+              sx={{
+                flex: 1,
+                height: 3,
+                background: color,
+                minWidth: 40,
+              }}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Box sx={{ maxWidth: 900, mx: 'auto', my: 4 }}>
+      {/* Current branch indicator */}
+      <Paper
+        sx={{
+          p: 2,
+          background: 'var(--paper-sunken)',
+          border: '1px solid var(--line)',
+          mb: 3,
+          borderRadius: 2,
+        }}
+      >
+        <Typography sx={{ fontSize: '0.85rem', color: 'var(--ink-soft)', mb: 1 }}>
+          You are on:
+        </Typography>
+        <Chip
+          label={`🌿 ${currentBranch === 'main' ? 'main' : 'feature/dark-mode'}`}
+          sx={{
+            bgcolor:
+              currentBranch === 'main'
+                ? 'var(--info-bg)'
+                : 'var(--feature-bg)',
+            color:
+              currentBranch === 'main'
+                ? 'var(--info)'
+                : 'var(--feature)',
+            fontWeight: 700,
+          }}
+        />
+      </Paper>
+
+      {/* Graph visualization */}
+      <Paper
+        sx={{
+          p: 3,
+          background: 'var(--paper-raised)',
+          border: '1px solid var(--line)',
+          borderRadius: 2,
+          mb: 3,
+          overflowX: 'auto',
+        }}
+      >
+        <Typography sx={{ fontWeight: 700, mb: 2, color: 'var(--ink)' }}>
+          Commit History
+        </Typography>
+
+        {/* Main branch */}
+        <Box sx={{ mb: 4 }}>
+          <Typography
+            sx={{
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              mb: 2,
+              color: 'var(--info)',
+            }}
+          >
+            main
+          </Typography>
+          {renderBranchLine(mainCommits, 'var(--info)')}
+        </Box>
+
+        {/* Feature branch (diverges from commit 3) */}
+        {!isMerged && (
+          <Box>
+            <Typography
+              sx={{
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                mb: 2,
+                color: 'var(--feature)',
+              }}
+            >
+              feature/dark-mode
+            </Typography>
+            {renderBranchLine(featureCommits, 'var(--feature)')}
+          </Box>
+        )}
+
+        {/* Merge indicator */}
+        {isMerged && (
+          <Box sx={{ mt: 3, p: 2, background: 'var(--success-bg)', borderRadius: 1 }}>
+            <Typography sx={{ color: 'var(--success)', fontWeight: 600 }}>
+              ✓ Merged! feature/dark-mode is now part of main.
+            </Typography>
+          </Box>
+        )}
+      </Paper>
+
+      {/* Action buttons */}
+      <Paper
+        sx={{
+          p: 2,
+          background: 'var(--paper-raised)',
+          border: '1px solid var(--line)',
+          borderRadius: 2,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+          <Button
+            onClick={() => setCurrentBranch('main')}
+            variant={currentBranch === 'main' ? 'contained' : 'outlined'}
+            sx={{
+              bgcolor:
+                currentBranch === 'main'
+                  ? 'var(--info)'
+                  : 'transparent',
+              borderColor: 'var(--line-strong)',
+              color: currentBranch === 'main' ? 'white' : 'var(--ink-soft)',
+              '&:hover': {
+                bgcolor:
+                  currentBranch === 'main'
+                    ? 'var(--info)'
+                    : 'var(--paper-sunken)',
+              },
+            }}
+          >
+            Switch to main
+          </Button>
+
+          <Button
+            onClick={() => setCurrentBranch('feature')}
+            variant={currentBranch === 'feature' ? 'contained' : 'outlined'}
+            sx={{
+              bgcolor:
+                currentBranch === 'feature'
+                  ? 'var(--feature)'
+                  : 'transparent',
+              borderColor: 'var(--line-strong)',
+              color:
+                currentBranch === 'feature'
+                  ? 'white'
+                  : 'var(--ink-soft)',
+              '&:hover': {
+                bgcolor:
+                  currentBranch === 'feature'
+                    ? 'var(--feature)'
+                    : 'var(--paper-sunken)',
+              },
+            }}
+          >
+            Switch to feature/dark-mode
+          </Button>
+
+          <Button
+            onClick={addCommit}
+            variant="contained"
+            disabled={isMerged}
+            sx={{
+              bgcolor: 'var(--info)',
+              color: 'white',
+              '&:hover': { bgcolor: 'var(--info)', opacity: 0.9 },
+              '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
+            }}
+          >
+            + Commit on {currentBranch}
+          </Button>
+
+          {!isMerged && (
+            <Button
+              onClick={merge}
+              variant="contained"
+              sx={{
+                bgcolor: 'var(--success)',
+                color: 'white',
+                '&:hover': { bgcolor: 'var(--success)', opacity: 0.9 },
+              }}
+            >
+              Merge feature/dark-mode → main
+            </Button>
+          )}
+
+          <Button
+            onClick={reset}
+            variant="outlined"
+            sx={{
+              borderColor: 'var(--line-strong)',
+              color: 'var(--ink-soft)',
+              '&:hover': { borderColor: 'var(--line)', bgcolor: 'var(--paper-sunken)' },
+            }}
+          >
+            Reset
+          </Button>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/components/pageComponents/VersionControl/SubComponents/CommitDemo.tsx
+++ b/components/pageComponents/VersionControl/SubComponents/CommitDemo.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Paper,
+  Chip,
+  Stack,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import {
+  INITIAL_CHANGED_FILES,
+  ChangedFile,
+  Commit,
+  generateCommitHash,
+  getCurrentTimestamp,
+} from '../CommittingConcept.constants';
+
+export default function CommitDemo() {
+  const [workingDir, setWorkingDir] = useState<ChangedFile[]>(INITIAL_CHANGED_FILES);
+  const [stagingArea, setStagingArea] = useState<ChangedFile[]>([]);
+  const [commitMessage, setCommitMessage] = useState('');
+  const [commits, setCommits] = useState<Commit[]>([]);
+  const [hasError, setHasError] = useState(false);
+
+  const moveToStaging = (file: ChangedFile) => {
+    setWorkingDir(workingDir.filter((f) => f.id !== file.id));
+    setStagingArea([...stagingArea, file]);
+  };
+
+  const moveBackToWorking = (file: ChangedFile) => {
+    setStagingArea(stagingArea.filter((f) => f.id !== file.id));
+    setWorkingDir([...workingDir, file]);
+  };
+
+  const handleCommit = () => {
+    if (stagingArea.length === 0) {
+      setHasError(true);
+      setTimeout(() => setHasError(false), 2000);
+      return;
+    }
+    if (!commitMessage.trim()) {
+      setHasError(true);
+      setTimeout(() => setHasError(false), 2000);
+      return;
+    }
+
+    const newCommit: Commit = {
+      hash: generateCommitHash(),
+      message: commitMessage,
+      timestamp: getCurrentTimestamp(),
+    };
+
+    setCommits([newCommit, ...commits]);
+    setStagingArea([]);
+    setCommitMessage('');
+    setHasError(false);
+  };
+
+  const handleReset = () => {
+    setWorkingDir(INITIAL_CHANGED_FILES);
+    setStagingArea([]);
+    setCommitMessage('');
+    setCommits([]);
+    setHasError(false);
+  };
+
+  const statusColor = (status: 'modified' | 'new') => {
+    return status === 'modified' ? 'var(--warning)' : 'var(--info)';
+  };
+
+  const statusLabel = (status: 'modified' | 'new') => {
+    return status === 'modified' ? 'modified' : 'new file';
+  };
+
+  return (
+    <Box sx={{ maxWidth: 900, mx: 'auto', my: 4 }}>
+      {/* Flow diagram */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 2, mb: 4 }}>
+        {/* Working Directory */}
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--paper-sunken)',
+            border: '2px solid var(--line-strong)',
+            minHeight: 300,
+            borderRadius: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: 700, mb: 2, color: 'var(--ink)' }}
+          >
+            Working Directory
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'var(--ink-faint)', display: 'block', mb: 2 }}
+          >
+            Changed files in your project
+          </Typography>
+          <Stack spacing={1}>
+            {workingDir.length === 0 ? (
+              <Typography
+                sx={{
+                  color: 'var(--ink-faint)',
+                  fontStyle: 'italic',
+                  textAlign: 'center',
+                  py: 3,
+                }}
+              >
+                No changes
+              </Typography>
+            ) : (
+              workingDir.map((file) => (
+                <Box
+                  key={file.id}
+                  sx={{
+                    p: 1,
+                    background: 'var(--paper-raised)',
+                    border: `1px solid var(--line)`,
+                    borderRadius: 1,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        fontSize: '0.85rem',
+                        color: 'var(--ink)',
+                        fontWeight: 500,
+                        wordBreak: 'break-word',
+                      }}
+                    >
+                      {file.name}
+                    </Typography>
+                    <Chip
+                      label={statusLabel(file.status)}
+                      size="small"
+                      sx={{
+                        mt: 0.5,
+                        bgcolor: statusColor(file.status),
+                        color: 'white',
+                        fontSize: '0.7rem',
+                      }}
+                    />
+                  </Box>
+                  <Button
+                    size="small"
+                    onClick={() => moveToStaging(file)}
+                    sx={{
+                      minWidth: 'auto',
+                      px: 1,
+                      py: 0.5,
+                      fontSize: '0.75rem',
+                      bgcolor: 'var(--info)',
+                      color: 'white',
+                      '&:hover': { bgcolor: 'var(--info)', opacity: 0.9 },
+                    }}
+                  >
+                    <AddIcon sx={{ fontSize: 14 }} />
+                  </Button>
+                </Box>
+              ))
+            )}
+          </Stack>
+        </Paper>
+
+        {/* Staging Area */}
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--paper-sunken)',
+            border: '2px solid var(--success)',
+            minHeight: 300,
+            borderRadius: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: 700, mb: 2, color: 'var(--ink)' }}
+          >
+            Staging Area
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'var(--ink-faint)', display: 'block', mb: 2 }}
+          >
+            Files ready to commit
+          </Typography>
+          <Stack spacing={1}>
+            {stagingArea.length === 0 ? (
+              <Typography
+                sx={{
+                  color: 'var(--ink-faint)',
+                  fontStyle: 'italic',
+                  textAlign: 'center',
+                  py: 3,
+                }}
+              >
+                Empty
+              </Typography>
+            ) : (
+              stagingArea.map((file) => (
+                <Box
+                  key={file.id}
+                  sx={{
+                    p: 1,
+                    background: 'var(--success-bg)',
+                    border: '1px solid var(--success)',
+                    borderRadius: 1,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        fontSize: '0.85rem',
+                        color: 'var(--ink)',
+                        fontWeight: 500,
+                        wordBreak: 'break-word',
+                      }}
+                    >
+                      {file.name}
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    onClick={() => moveBackToWorking(file)}
+                    sx={{
+                      minWidth: 'auto',
+                      px: 1,
+                      py: 0.5,
+                      fontSize: '0.75rem',
+                      bgcolor: 'var(--success)',
+                      color: 'white',
+                      '&:hover': { bgcolor: 'var(--success)', opacity: 0.9 },
+                    }}
+                  >
+                    −
+                  </Button>
+                </Box>
+              ))
+            )}
+          </Stack>
+        </Paper>
+
+        {/* Commit History */}
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--paper-sunken)',
+            border: '2px solid var(--feature)',
+            minHeight: 300,
+            borderRadius: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: 700, mb: 2, color: 'var(--ink)' }}
+          >
+            Commit History
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'var(--ink-faint)', display: 'block', mb: 2 }}
+          >
+            Snapshots of your work
+          </Typography>
+          <Stack spacing={1}>
+            {commits.length === 0 ? (
+              <Typography
+                sx={{
+                  color: 'var(--ink-faint)',
+                  fontStyle: 'italic',
+                  textAlign: 'center',
+                  py: 3,
+                }}
+              >
+                No commits yet
+              </Typography>
+            ) : (
+              commits.map((commit) => (
+                <Box
+                  key={commit.hash}
+                  sx={{
+                    p: 1.5,
+                    background: 'var(--feature-bg)',
+                    border: '1px solid var(--feature)',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Box sx={{ display: 'flex', gap: 1, mb: 0.5 }}>
+                    <CheckCircleIcon
+                      sx={{ fontSize: 16, color: 'var(--success)', flexShrink: 0 }}
+                    />
+                    <Typography
+                      sx={{
+                        fontSize: '0.75rem',
+                        fontFamily: 'monospace',
+                        color: 'var(--ink-soft)',
+                      }}
+                    >
+                      {commit.hash}
+                    </Typography>
+                  </Box>
+                  <Typography
+                    sx={{
+                      fontSize: '0.85rem',
+                      color: 'var(--ink)',
+                      fontWeight: 500,
+                      wordBreak: 'break-word',
+                      ml: 3,
+                    }}
+                  >
+                    {commit.message}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.7rem',
+                      color: 'var(--ink-faint)',
+                      ml: 3,
+                      mt: 0.5,
+                    }}
+                  >
+                    {commit.timestamp}
+                  </Typography>
+                </Box>
+              ))
+            )}
+          </Stack>
+        </Paper>
+      </Box>
+
+      {/* Message input and buttons */}
+      <Paper
+        sx={{
+          p: 3,
+          background: 'var(--paper-raised)',
+          border: '1px solid var(--line)',
+          borderRadius: 2,
+          mb: 2,
+        }}
+      >
+        <TextField
+          fullWidth
+          label="Commit message"
+          placeholder="Describe what you changed..."
+          value={commitMessage}
+          onChange={(e) => setCommitMessage(e.target.value)}
+          multiline
+          rows={2}
+          sx={{ mb: 2 }}
+          error={hasError && (!commitMessage.trim() || stagingArea.length === 0)}
+          helperText={
+            hasError && stagingArea.length === 0
+              ? 'Add files to the staging area first'
+              : hasError && !commitMessage.trim()
+              ? 'Write a commit message'
+              : ''
+          }
+        />
+
+        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+          <Button
+            onClick={handleReset}
+            variant="outlined"
+            sx={{
+              borderColor: 'var(--line-strong)',
+              color: 'var(--ink-soft)',
+              '&:hover': { borderColor: 'var(--line)', bgcolor: 'var(--paper-sunken)' },
+            }}
+          >
+            Reset
+          </Button>
+          <Button
+            onClick={handleCommit}
+            variant="contained"
+            sx={{
+              bgcolor: 'var(--feature)',
+              color: 'white',
+              '&:hover': { bgcolor: 'var(--feature)', opacity: 0.9 },
+            }}
+          >
+            Commit
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/components/pageComponents/VersionControl/SubComponents/PushDemo.tsx
+++ b/components/pageComponents/VersionControl/SubComponents/PushDemo.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  Typography,
+  Paper,
+  Chip,
+  Stack,
+} from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import SyncAltIcon from '@mui/icons-material/SyncAlt';
+import { INITIAL_COMMITS, Commit } from '../PushingConcept.constants';
+
+export default function PushDemo() {
+  const [remoteCommits, setRemoteCommits] = useState<Commit[]>(INITIAL_COMMITS);
+  const [localCommits, setLocalCommits] = useState<Commit[]>(INITIAL_COMMITS);
+  const [aheadBy, setAheadBy] = useState(0);
+  const [isPushing, setIsPushing] = useState(false);
+  const [pushMessage, setPushMessage] = useState('');
+
+  useEffect(() => {
+    setAheadBy(Math.max(0, localCommits.length - remoteCommits.length));
+  }, [localCommits, remoteCommits]);
+
+  const addLocalCommit = () => {
+    const newCommit: Commit = {
+      hash: Math.random().toString(16).substring(2, 8).toUpperCase(),
+      message: `New commit #${localCommits.length + 1}`,
+    };
+    setLocalCommits([...localCommits, newCommit]);
+  };
+
+  const handlePush = async () => {
+    if (aheadBy === 0) return;
+
+    setIsPushing(true);
+    setPushMessage('');
+
+    // Simulate push animation
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Add pending commits to remote
+    const pendingCommits = localCommits.slice(remoteCommits.length);
+    setRemoteCommits([...remoteCommits, ...pendingCommits]);
+
+    setPushMessage(`✓ Pushed ${pendingCommits.length} commit(s) to GitHub!`);
+    setIsPushing(false);
+
+    // Clear message after 3 seconds
+    setTimeout(() => setPushMessage(''), 3000);
+  };
+
+  const handleReset = () => {
+    setLocalCommits(INITIAL_COMMITS);
+    setRemoteCommits(INITIAL_COMMITS);
+    setAheadBy(0);
+    setPushMessage('');
+  };
+
+  const renderCommit = (commit: Commit, isAnimating: boolean) => (
+    <Box
+      key={commit.hash}
+      sx={{
+        p: 1.5,
+        background: 'var(--paper-raised)',
+        border: '1px solid var(--line)',
+        borderRadius: 1,
+        display: 'flex',
+        gap: 2,
+        alignItems: 'center',
+        animation: isAnimating
+          ? 'slideRight 0.8s ease-out forwards'
+          : 'none',
+        '@keyframes slideRight': {
+          from: { opacity: 0.5, transform: 'translateX(-40px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: '50%',
+          background: 'var(--info-bg)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          color: 'var(--info)',
+          fontFamily: 'monospace',
+          fontWeight: 700,
+          fontSize: '0.75rem',
+        }}
+      >
+        {commit.hash}
+      </Box>
+      <Typography
+        sx={{
+          flex: 1,
+          fontSize: '0.9rem',
+          color: 'var(--ink)',
+          fontWeight: 500,
+        }}
+      >
+        {commit.message}
+      </Typography>
+    </Box>
+  );
+
+  const animatingCommits = localCommits.slice(remoteCommits.length);
+
+  return (
+    <Box sx={{ maxWidth: 900, mx: 'auto', my: 4 }}>
+      {/* Status indicator */}
+      <Paper
+        sx={{
+          p: 2.5,
+          background:
+            aheadBy > 0
+              ? 'var(--warning-bg)'
+              : 'var(--success-bg)',
+          border:
+            aheadBy > 0
+              ? '1px solid var(--warning)'
+              : '1px solid var(--success)',
+          borderRadius: 2,
+          mb: 3,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <SyncAltIcon
+            sx={{
+              color: aheadBy > 0 ? 'var(--warning)' : 'var(--success)',
+            }}
+          />
+          <Typography sx={{ fontWeight: 700, color: 'var(--ink)' }}>
+            Sync Status
+          </Typography>
+        </Box>
+        {aheadBy > 0 ? (
+          <Typography sx={{ color: 'var(--ink-soft)' }}>
+            Your local repository is <b>ahead by {aheadBy} commit{aheadBy !== 1 ? 's' : ''}</b>. Push to sync with GitHub.
+          </Typography>
+        ) : (
+          <Typography sx={{ color: 'var(--ink-soft)' }}>
+            Your local and remote repositories are <b>in sync</b>. Good job!
+          </Typography>
+        )}
+      </Paper>
+
+      {/* Two-panel layout */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        {/* Local Repository */}
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--paper-sunken)',
+            border: '2px solid var(--line-strong)',
+            borderRadius: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 700,
+              mb: 2,
+              color: 'var(--ink)',
+            }}
+          >
+            Local Repository
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'var(--ink-faint)', display: 'block', mb: 2 }}
+          >
+            Your computer
+          </Typography>
+          <Stack spacing={1}>
+            {localCommits.map((commit, index) => {
+              const isAnimating =
+                animatingCommits.some((ac) => ac.hash === commit.hash);
+              return renderCommit(commit, isAnimating);
+            })}
+          </Stack>
+        </Paper>
+
+        {/* Remote Repository */}
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--paper-sunken)',
+            border: '2px solid var(--line-strong)',
+            borderRadius: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 700,
+              mb: 2,
+              color: 'var(--ink)',
+            }}
+          >
+            Remote Repository
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'var(--ink-faint)', display: 'block', mb: 2 }}
+          >
+            GitHub / GitLab
+          </Typography>
+          <Stack spacing={1}>
+            {remoteCommits.map((commit) =>
+              renderCommit(commit, false)
+            )}
+            {remoteCommits.length === 0 && (
+              <Typography
+                sx={{
+                  color: 'var(--ink-faint)',
+                  fontStyle: 'italic',
+                  textAlign: 'center',
+                  py: 3,
+                }}
+              >
+                Empty
+              </Typography>
+            )}
+          </Stack>
+        </Paper>
+      </Box>
+
+      {/* Push message */}
+      {pushMessage && (
+        <Paper
+          sx={{
+            p: 2,
+            background: 'var(--success-bg)',
+            border: '1px solid var(--success)',
+            borderRadius: 2,
+            mb: 2,
+            textAlign: 'center',
+          }}
+        >
+          <Typography sx={{ color: 'var(--success)', fontWeight: 600 }}>
+            {pushMessage}
+          </Typography>
+        </Paper>
+      )}
+
+      {/* Action buttons */}
+      <Paper
+        sx={{
+          p: 2,
+          background: 'var(--paper-raised)',
+          border: '1px solid var(--line)',
+          borderRadius: 2,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+          <Button
+            onClick={addLocalCommit}
+            variant="contained"
+            sx={{
+              bgcolor: 'var(--info)',
+              color: 'white',
+              '&:hover': { bgcolor: 'var(--info)', opacity: 0.9 },
+            }}
+          >
+            + Make Local Commit
+          </Button>
+
+          <Button
+            onClick={handlePush}
+            disabled={aheadBy === 0 || isPushing}
+            variant="contained"
+            sx={{
+              bgcolor: 'var(--feature)',
+              color: 'white',
+              '&:hover': { bgcolor: 'var(--feature)', opacity: 0.9 },
+              '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
+            }}
+          >
+            <CloudUploadIcon sx={{ mr: 1, fontSize: 18 }} />
+            Push to GitHub
+          </Button>
+
+          <Button
+            onClick={handleReset}
+            variant="outlined"
+            sx={{
+              borderColor: 'var(--line-strong)',
+              color: 'var(--ink-soft)',
+              '&:hover': { borderColor: 'var(--line)', bgcolor: 'var(--paper-sunken)' },
+            }}
+          >
+            Reset
+          </Button>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/components/pageComponents/VersionControl/VersionControlPage.tsx
+++ b/components/pageComponents/VersionControl/VersionControlPage.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import PageWrapper from '../../common/PageWrapper';
+import GenericIntroduction from '../../common/GenericIntroduction';
+import CommittingConcept from './CommittingConcept';
+import BranchingConcept from './BranchingConcept';
+import PushingConcept from './PushingConcept';
+import SaveIcon from '@mui/icons-material/Save';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import { versionControlNavItems as navItems } from '../navItems';
+
+export default function VersionControlPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [selectedConcept, setSelectedConcept] = useState<string | null>(null);
+
+  useEffect(() => {
+    const conceptFromUrl = searchParams.get('concept');
+    if (conceptFromUrl) {
+      setSelectedConcept(conceptFromUrl);
+    }
+  }, [searchParams]);
+
+  const renderContent = (concept: string | null) => {
+    if (!concept) return null;
+
+    switch (concept.toLowerCase()) {
+      case 'introduction':
+        return (
+          <GenericIntroduction
+            title="Welcome to Version Control"
+            paragraphs={[
+              "Version control is a system that tracks changes to your code over time. It lets you save snapshots of your work, explore different ideas in parallel branches, and collaborate safely with teammates by managing who changes what.",
+              "In this section you'll learn how to commit changes, create branches to work on features in isolation, and push your work to a remote repository like GitHub.",
+            ]}
+            steps={[
+              { icon: <SaveIcon sx={{ fontSize: 48, color: 'var(--info)' }} />, label: 'Committing Changes' },
+              { icon: <CallSplitIcon sx={{ fontSize: 48, color: 'var(--success)' }} />, label: 'Branching' },
+              { icon: <CloudUploadIcon sx={{ fontSize: 48, color: 'var(--feature)' }} />, label: 'Pushing to Remote' },
+            ]}
+            closing="Understanding these core Git concepts will help you work confidently on any software project. Let's get started!"
+          />
+        );
+      case 'committing':
+        return <CommittingConcept />;
+      case 'branching':
+        return <BranchingConcept />;
+      case 'pushing':
+        return <PushingConcept />;
+      default:
+        return null;
+    }
+  };
+
+  const handleSelect = (value: string) => {
+    router.push(`/skills/version-control?concept=${value}`);
+    setSelectedConcept(value);
+  };
+
+  return (
+    <PageWrapper
+      pageTitle="Version Control"
+      navItems={navItems}
+      defaultOpen={['getting-started', 'core-git-workflow']}
+      handleSelect={handleSelect}
+      activeValue={selectedConcept || undefined}
+    >
+      {selectedConcept ? (
+        <>
+          {renderContent(selectedConcept)}
+        </>
+      ) : (
+        <div className="empty-page-prompt">
+          Please select a topic from the sidebar to get started.
+        </div>
+      )}
+    </PageWrapper>
+  );
+}

--- a/components/pageComponents/navItems.ts
+++ b/components/pageComponents/navItems.ts
@@ -483,3 +483,22 @@ export const projectManagementNavItems: SidebarItem[] = [
     ],
   },
 ];
+
+export const versionControlNavItems: SidebarItem[] = [
+  {
+    label: 'Getting Started',
+    value: 'getting-started',
+    children: [
+      { label: 'Introduction', value: 'introduction' },
+    ],
+  },
+  {
+    label: 'Core Git Workflow',
+    value: 'core-git-workflow',
+    children: [
+      { label: 'Committing Changes', value: 'committing' },
+      { label: 'Branching', value: 'branching' },
+      { label: 'Pushing to a Remote', value: 'pushing' },
+    ],
+  },
+];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   faShieldHalved,
   faSitemap,
   faClipboardList,
+  faCodeBranch,
 } from '@fortawesome/free-solid-svg-icons';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import CodeIcon from '@mui/icons-material/Code';
@@ -40,6 +41,7 @@ const iconById: Record<string, IconDefinition> = {
   'software-testing': faBug,
   'website-management': faSitemap,
   'project-management': faClipboardList,
+  'version-control': faCodeBranch,
 };
 
 type Filter = TopicCategory | 'all';

--- a/src/app/skills/version-control/page.tsx
+++ b/src/app/skills/version-control/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react';
+import Loader from '@/components/common/Loader';
+import VersionControlPage from '@/components/pageComponents/VersionControl/VersionControlPage';
+
+export default function Page() {
+  return (
+    <Suspense fallback={<Loader/>}>
+      <VersionControlPage />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
Add a new /skills/version-control topic to the landing web with three interactive, theme-aware concepts:
- Committing: working directory -> staging area -> commit history demo
- Branching: live commit graph with branch/switch/merge
- Pushing: local vs remote panels with an ahead-by-N push-to-sync animation

Wires the topic into the landing tile grid, 3D graph, and concept search (topics.ts, conceptIndex.ts, page.tsx icon, navItems.ts) and adds the Suspense route. Components use theme tokens only and are split into SubComponents/constants per the repo conventions.